### PR TITLE
Advance Router Structure & FreeBoardDetail Page Publishing

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -11,4 +11,7 @@ import { RouterView } from 'vue-router'
 </template>
 
 <style>
+.v-application {
+  font-family: 'Pretendard', sans-serif !important;
+}
 </style>

--- a/src/components/comment/CommentForm.vue
+++ b/src/components/comment/CommentForm.vue
@@ -1,0 +1,22 @@
+<script setup>
+defineEmits(['submit'])
+</script>
+
+<template>
+  <div class="flex gap-4">
+    <div
+      class="flex items-center gap-2 border border-black4 px-5 py-3 rounded bg-black1 dark:bg-black9"
+    >
+      <input
+        type="text"
+        class="outline-none bg-transparent dark:caret-black1 dark:text-black1 w-full"
+        placeholder="내용을 입력해주세요."
+      />
+    </div>
+    <button
+      class="w-28 font-bold bg-black8 py-3 rounded text-black1 dark:bg-black3 dark:text-black9"
+    >
+      등록
+    </button>
+  </div>
+</template>

--- a/src/components/comment/CommentList.vue
+++ b/src/components/comment/CommentList.vue
@@ -1,0 +1,55 @@
+<script setup>
+import getRelativeTime from '@/utils/getRelativeTime'
+
+defineProps({
+  comments: {
+    type: Array,
+    required: true,
+    default: () => [],
+  },
+})
+</script>
+
+<template>
+  <ul class="list-none pl-0 flex flex-col gap-4">
+    <li v-for="comment in comments" :key="comment.id" class="flex gap-4">
+      <div class="w-11 h-10 rounded-full overflow-hidden">
+        <img
+          :src="comment.author.coverImage"
+          alt="profile image"
+          class="w-full h-full object-cover"
+        />
+      </div>
+      <div class="w-full flex flex-col gap-2">
+        <div class="flex justify-between">
+          <div>
+            <span class="text-body1 font-bold dark:text-black1">{{ comment.author.fullName }}</span>
+            <span class="text-body1 font-light text-black4">
+              • {{ getRelativeTime(comment.createdAt) }}</span
+            >
+          </div>
+          <div class="max-w-10 text-primaryRed flex items-center gap-2 justify-end cursor-pointer">
+            <svg
+              width="15"
+              height="14"
+              viewBox="0 0 13 12"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M12 3.72727C12 2.22104 10.7175 1 9.13542 1C7.95254 1 6.93712 1.68259 6.5 2.65662C6.06288 1.68259 5.04746 1 3.86458 1C2.28252 1 1 2.22104 1 3.72727C1 8.10337 6.5 11 6.5 11C6.5 11 12 8.10337 12 3.72727Z"
+                stroke="#DC3644"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+            {{ comment.likes }}
+          </div>
+        </div>
+        <p class="text-body2 font-light dark:text-black1">
+          {{ comment.content }}
+        </p>
+      </div>
+    </li>
+  </ul>
+</template>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,23 +1,14 @@
 import { createRouter, createWebHistory } from 'vue-router'
-import Bicycle  from '@/views/bicycle/Bicycle.vue';
+import {
+  FREEBOARD_ROUTES,
+  BICYCLE_ROUTES,
+  USER_ROUTES,
+  NEWS_ROUTES,
+  QNABOARD_ROUTES,
+  RIDERPARTS_ROUTES,
+} from './routes'
 import Main from '@/views/main/Main.vue'
-import BicycleDetail from '@/views/bicycle/bicycleDetail/BicycleDetail.vue'
-import BicycleSearch from '@/views/bicycle/bicycleSearch/BicycleSearch.vue'
-import FreeBoard from '@/views/freeBoard/FreeBoard.vue'
-import FreeBoardDetail from '@/views/freeBoard/freeBoardDetail/FreeBoardDetail.vue'
-import FreeBoardEdit from '@/views/freeBoard/freeBoardEdit/FreeBoardEdit.vue'
 import RoadMap from '@/views/roadMap/RoadMap.vue'
-import News from '@/views/news/News.vue'
-import NewsDetail from '@/views/news/newsDetail/NewsDetail.vue'
-import QnaBoard from '@/views/qnaBoard/QnaBoard.vue'
-import QnaBoardEdit from '@/views/qnaBoard/qnaBoardEdit/QnaBoardEdit.vue'
-import QnaBoardDetail from '@/views/qnaBoard/qnaBoardDetail/QnaBoardDetail.vue'
-import RiderParts from '@/views/riderParts/RiderParts.vue'
-import RiderPartSearch from '@/views/riderParts/roaderSearch/RiderPartSearch.vue'
-import RiderPartDetail from '@/views/riderParts/roaderDetail/RiderPartDetail.vue'
-import Login from '@/views/user/login/Login.vue'
-import MyPage from '@/views/user/myPage/MyPage.vue'
-import Signup from '@/views/user/signup/Signup.vue'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -25,98 +16,19 @@ const router = createRouter({
     {
       path: '/',
       name: 'home',
-      component: Main
-    },
-    {
-      path: '/bicycle',
-      name: 'bicycle',
-      component: Bicycle
-    },
-    {
-      path: '/bicycleDetail',
-      name: 'bicycleDetail',
-      component: BicycleDetail
-    },
-    {
-      path: '/bicycleSearch',
-      name: 'bicycleSearch',
-      component: BicycleSearch
-    },
-    {
-      path: '/freeBoard',
-      name: 'FreeBoard',
-      component: FreeBoard
-    },
-    {
-      path: '/freeBoardDetail',
-      name: 'FreeBoardDetail',
-      component: FreeBoardDetail
-    },
-    {
-      path: '/freeBoardEdit',
-      name: 'FreeBoardEdit',
-      component: FreeBoardEdit
+      component: Main,
     },
     {
       path: '/roadMap',
       name: 'RoadMap',
-      component: RoadMap
+      component: RoadMap,
     },
-    {
-      path: '/news',
-      name: 'News',
-      component: News
-    },
-    {
-      path: '/newsDetail',
-      name: 'NewsDetail',
-      component: NewsDetail
-    },
-    {
-      path: '/qnaBoard',
-      name: 'QnaBoard',
-      component: QnaBoard
-    },
-    {
-      path: '/qnaBoardEdit',
-      name: 'QnaBoardEdit',
-      component: QnaBoardEdit
-    },
-    {
-      path: '/qnaBoardDetail',
-      name: 'QnaBoardDetail',
-      component: QnaBoardDetail
-    },
-    {
-      path: '/riderParts',
-      name: 'RiderParts',
-      component: RiderParts
-    },
-    {
-      path: '/riderPartsSearch',
-      name: 'RiderPartsSearch',
-      component: RiderPartSearch
-    },
-    {
-      path: '/riderPartsDetail',
-      name: 'RiderPartsDetail',
-      component: RiderPartDetail
-    },
-    {
-      path: '/login',
-      name: 'Login',
-      component: Login
-    },
-    {
-      path: '/myPage',
-      name: 'MyPage',
-      component: MyPage
-    },
-    {
-      path: '/signup',
-      name: 'Signup',
-      component: Signup
-    },
+    ...BICYCLE_ROUTES,
+    ...FREEBOARD_ROUTES,
+    ...NEWS_ROUTES,
+    ...QNABOARD_ROUTES,
+    ...RIDERPARTS_ROUTES,
+    ...USER_ROUTES,
   ],
 })
 

--- a/src/router/routes/BICYCLE_ROUTES.js
+++ b/src/router/routes/BICYCLE_ROUTES.js
@@ -1,0 +1,23 @@
+import Bicycle from '@/views/bicycle/Bicycle.vue'
+import BicycleDetail from '@/views/bicycle/bicycleDetail/BicycleDetail.vue'
+import BicycleSearch from '@/views/bicycle/bicycleSearch/BicycleSearch.vue'
+
+const BICYCLE_ROUTES = [
+  {
+    path: '/bicycle',
+    name: 'bicycle',
+    component: Bicycle,
+  },
+  {
+    path: '/bicycleDetail',
+    name: 'bicycleDetail',
+    component: BicycleDetail,
+  },
+  {
+    path: '/bicycleSearch',
+    name: 'bicycleSearch',
+    component: BicycleSearch,
+  },
+]
+
+export default BICYCLE_ROUTES

--- a/src/router/routes/FREEBOARD_ROUTES.js
+++ b/src/router/routes/FREEBOARD_ROUTES.js
@@ -9,12 +9,12 @@ const FREEBOARD_ROUTES = [
     component: FreeBoard,
   },
   {
-    path: '/freeBoardDetail',
+    path: '/freeBoardDetail/:id',
     name: 'FreeBoardDetail',
     component: FreeBoardDetail,
   },
   {
-    path: '/freeBoardEdit',
+    path: '/freeBoardEdit/:id',
     name: 'FreeBoardEdit',
     component: FreeBoardEdit,
   },

--- a/src/router/routes/FREEBOARD_ROUTES.js
+++ b/src/router/routes/FREEBOARD_ROUTES.js
@@ -1,0 +1,22 @@
+import FreeBoard from '@/views/freeBoard/FreeBoard.vue'
+import FreeBoardDetail from '@/views/freeBoard/freeBoardDetail/FreeBoardDetail.vue'
+import FreeBoardEdit from '@/views/freeBoard/freeBoardEdit/FreeBoardEdit.vue'
+
+const FREEBOARD_ROUTES = [
+  {
+    path: '/freeBoard',
+    name: 'FreeBoard',
+    component: FreeBoard,
+  },
+  {
+    path: '/freeBoardDetail',
+    name: 'FreeBoardDetail',
+    component: FreeBoardDetail,
+  },
+  {
+    path: '/freeBoardEdit',
+    name: 'FreeBoardEdit',
+    component: FreeBoardEdit,
+  },
+]
+export default FREEBOARD_ROUTES

--- a/src/router/routes/NEWS_ROUTES.js
+++ b/src/router/routes/NEWS_ROUTES.js
@@ -1,0 +1,16 @@
+import News from '@/views/news/News.vue'
+import NewsDetail from '@/views/news/newsDetail/NewsDetail.vue'
+
+const NEWS_ROUTES = [
+  {
+    path: '/news',
+    name: 'News',
+    component: News,
+  },
+  {
+    path: '/newsDetail',
+    name: 'NewsDetail',
+    component: NewsDetail,
+  },
+]
+export default NEWS_ROUTES

--- a/src/router/routes/QNABOARD_ROUTES.js
+++ b/src/router/routes/QNABOARD_ROUTES.js
@@ -1,0 +1,22 @@
+import QnaBoard from '@/views/qnaBoard/QnaBoard.vue'
+import QnaBoardDetail from '@/views/qnaBoard/qnaBoardDetail/QnaBoardDetail.vue'
+import QnaBoardEdit from '@/views/qnaBoard/qnaBoardEdit/QnaBoardEdit.vue'
+
+const QNABOARD_ROUTES = [
+  {
+    path: '/qnaBoard',
+    name: 'QnaBoard',
+    component: QnaBoard,
+  },
+  {
+    path: '/qnaBoardEdit',
+    name: 'QnaBoardEdit',
+    component: QnaBoardEdit,
+  },
+  {
+    path: '/qnaBoardDetail',
+    name: 'QnaBoardDetail',
+    component: QnaBoardDetail,
+  },
+]
+export default QNABOARD_ROUTES

--- a/src/router/routes/RIDERPARTS_ROUTES.js
+++ b/src/router/routes/RIDERPARTS_ROUTES.js
@@ -1,0 +1,22 @@
+import RiderParts from '@/views/riderParts/RiderParts.vue'
+import RiderPartDetail from '@/views/riderParts/roaderDetail/RiderPartDetail.vue'
+import RiderPartSearch from '@/views/riderParts/roaderSearch/RiderPartSearch.vue'
+
+const RIDERPARTS_ROUTES = [
+  {
+    path: '/riderParts',
+    name: 'RiderParts',
+    component: RiderParts,
+  },
+  {
+    path: '/riderPartsSearch',
+    name: 'RiderPartsSearch',
+    component: RiderPartSearch,
+  },
+  {
+    path: '/riderPartsDetail',
+    name: 'RiderPartsDetail',
+    component: RiderPartDetail,
+  },
+]
+export default RIDERPARTS_ROUTES

--- a/src/router/routes/USER_ROUTES.js
+++ b/src/router/routes/USER_ROUTES.js
@@ -1,0 +1,22 @@
+import Login from '@/views/user/login/Login.vue'
+import MyPage from '@/views/user/myPage/MyPage.vue'
+import Signup from '@/views/user/signup/Signup.vue'
+
+const USER_ROUTES = [
+  {
+    path: '/login',
+    name: 'Login',
+    component: Login,
+  },
+  {
+    path: '/myPage',
+    name: 'MyPage',
+    component: MyPage,
+  },
+  {
+    path: '/signup',
+    name: 'Signup',
+    component: Signup,
+  },
+]
+export default USER_ROUTES

--- a/src/router/routes/index.js
+++ b/src/router/routes/index.js
@@ -1,0 +1,6 @@
+export { default as USER_ROUTES } from './USER_ROUTES'
+export { default as BICYCLE_ROUTES } from './BICYCLE_ROUTES'
+export { default as FREEBOARD_ROUTES } from './FREEBOARD_ROUTES'
+export { default as NEWS_ROUTES } from './NEWS_ROUTES'
+export { default as QNABOARD_ROUTES } from './QNABOARD_ROUTES'
+export { default as RIDERPARTS_ROUTES } from './RIDERPARTS_ROUTES'

--- a/src/views/freeBoard/FreeBoard.vue
+++ b/src/views/freeBoard/FreeBoard.vue
@@ -294,7 +294,9 @@ const dummyPosts = [
             조회순
           </button>
         </div>
-        <button class="bg-black6 px-6 py-2 rounded text-black1">글쓰기</button>
+        <router-link to="/freeBoard/write" class="bg-black6 px-6 py-2 rounded text-black1"
+          >글쓰기</router-link
+        >
       </section>
 
       <!-- 게시글 목록 영역 -->

--- a/src/views/freeBoard/components/FreeBoardListItem.vue
+++ b/src/views/freeBoard/components/FreeBoardListItem.vue
@@ -1,7 +1,7 @@
 <script setup>
 import getRelativeTime from '@/utils/getRelativeTime'
 
-defineProps({
+const { post } = defineProps({
   post: {
     type: Object,
     required: true,
@@ -9,7 +9,8 @@ defineProps({
 })
 </script>
 <template>
-  <article
+  <router-link
+    :to="`/freeBoardDetail/${post.id}`"
     class="min-h-64 col-span-3 flex flex-col bg-black1 drop-shadow-custom2 rounded-xl overflow-hidden dark:bg-black7 dark:text-black1 relative"
   >
     <div
@@ -27,7 +28,7 @@ defineProps({
           fill="#DC3644"
         />
       </svg>
-      <span class="text-body2 text-primaryRed">{{ post.likes }}</span>
+      <span class="text-body1 text-primaryRed">{{ post.likes }}</span>
     </div>
     <div
       class="flex items-center gap-2 rounded-t-lg overflow-hidden border-b-[0.5px] border-black4"
@@ -39,8 +40,8 @@ defineProps({
       />
     </div>
     <div class="flex flex-col gap-2 p-4">
-      <h3 class="font-bold">{{ post.title }}</h3>
-      <p class="text-sm line-clamp-3 mb-8 font-light">
+      <h3 class="text-sub-title font-bold">{{ post.title }}</h3>
+      <p class="text-body1 line-clamp-3 font-light">
         {{ post.content }}
       </p>
       <div class="flex items-center gap-2 overflow-hidden">
@@ -80,9 +81,9 @@ defineProps({
             stroke-linecap="round"
           />
         </svg>
-        <span class="text-body2 text-black4">{{ post.tags.join(' • ') }}</span>
+        <span class="text-body1 text-black4">{{ post.tags.join(' • ') }}</span>
       </div>
-      <div class="flex justify-between">
+      <div class="flex justify-between items-center">
         <div class="flex items-center gap-2">
           <div class="w-5 h-5 rounded-full overflow-hidden">
             <img
@@ -91,12 +92,12 @@ defineProps({
               class="w-full h-full object-cover"
             />
           </div>
-          <span class="text-sm">{{ post.author?.fullName }}</span>
+          <span class="text-body1">{{ post.author?.fullName }}</span>
         </div>
         <div>
-          <span class="text-sm">{{ getRelativeTime(post.createdAt) }}</span>
+          <span class="text-body1">{{ getRelativeTime(post.createdAt) }}</span>
         </div>
       </div>
     </div>
-  </article>
+  </router-link>
 </template>

--- a/src/views/freeBoard/freeBoardDetail/FreeBoardDetail.vue
+++ b/src/views/freeBoard/freeBoardDetail/FreeBoardDetail.vue
@@ -1,11 +1,193 @@
 <script setup>
+import BasicHeader from '@/components/BasicHeader.vue'
+import BasicFooter from '@/components/BasicFooter.vue'
+import CommentForm from '@/components/comment/CommentForm.vue'
+import CommentList from '@/components/comment/CommentList.vue'
+import getRelativeTime from '@/utils/getRelativeTime'
 
+const DUMMY_POST = {
+  id: 1,
+  image: 'https://placehold.co/620x400?text=RideOn',
+  title: '자전거로 에베레스트를 등반하다',
+  content: `이게 어려워?” <br />학교 선배님들이 저에게 자주 하던 말이었습니다. <br />
+            처음에는 단순한 장난이라고 생각했지만, 시간이 지나면서 그 말의 의미가 달라 보이기
+            시작했습니다. 그들은 정말로 묻고 있던 걸까요?<br />
+            아니면 제 한계를 시험하고 있었던 걸까요? 어떤 도전이든, 시작하기 전에는 어려워 보일
+            수밖에 없습니다. 하지만 막상 도전하면 생각보다 쉬울 수도 있고, 반대로 예상보다 훨씬 힘들
+            수도 있죠. 저는 이런 생각을 하며 자전거를 타고 에베레스트를 등반하기로 결심했습니다.
+            <br />물론, 실제로 에베레스트 정상까지 자전거를 타고 오를 수는 없습니다. 대신
+            '에베레스팅(Everesting)'이라는 도전이 있습니다. 한 번의 라이딩에서 같은 언덕을 반복해서
+            올라 총 상승 고도가 8,848m, 즉 에베레스트의 높이에 도달하는 것입니다. 이 도전은 단순한
+            체력 싸움이 아니라, 정신력과 끈기가 필요한 극한의 도전입니다. <br />처음엔 가벼운
+            마음으로 시작했습니다. "이게 어려워?"라고 스스로에게 물으며 페달을 밟았습니다. 하지만 몇
+            시간 후, 다리는 무거워지고, 숨은 거칠어지고, 내리막길에서도 자전거를 더 이상 탄력 있게
+            몰 수 없을 정도로 지쳤습니다. <br />그 순간, 선배들의 말이 다시 떠올랐습니다. "이게
+            어려워?" <br />맞아요. 어렵습니다. 하지만 그렇다고 포기할 수는 없습니다. 도전이 쉽다면,
+            의미가 없을 테니까요. 수십 번의 오르막과 내리막을 반복하며 새벽이 되었고, 마지막
+            오르막에 다다랐을 때 온몸이 부서질 듯한 고통이 밀려왔습니다. 하지만 저는 끝까지 페달을
+            밟았습니다. 그리고 마침내, 에베레스트와 같은 높이에 도달했을 때 깨달았습니다. <br />어떤
+            도전이든, 결국엔 내가 해낼 수 있느냐의 문제라는 것을. <br />"이게 어려워?" <br />이제는
+            제가 후배들에게 묻고 싶은 말입니다.`,
+  views: 142,
+  likes: 15,
+  tags: ['로드바이크', '입문', '장비추천'],
+  author: {
+    fullName: '바이크초보',
+    coverImage: 'https://placehold.co/20x20?text=RideOn',
+  },
+  createdAt: '2025-01-31T08:27:40.227Z',
+  comments: [
+    {
+      id: 1,
+      content:
+        '도전하는 모습이 정말 멋지네요! 결국 중요한 건 어려운 게 아니라, 해낼 수 있느냐의 문제라는 말이 인상 깊어요. 저도 제 한계를 시험해보고 싶어졌습니다!',
+      likes: 15,
+      author: {
+        fullName: '바이크초보',
+        coverImage: 'https://placehold.co/40x40?text=RideOn',
+      },
+      createdAt: '2025-01-31T08:27:40.227Z',
+    },
+    {
+      id: 2,
+      content:
+        '에베레스팅이라는 도전 정말 대단하네요! 저도 언젠가 한번 도전해보고 싶습니다. 어떤 코스로 도전하셨는지 궁금해요.',
+      likes: 8,
+      author: {
+        fullName: '산악라이더',
+        coverImage: 'https://placehold.co/40x40?text=RideOn',
+      },
+      createdAt: '2025-01-31T09:15:22.227Z',
+    },
+  ],
+}
 </script>
 
 <template>
+  <div class="w-full block h-full dark:bg-black9">
+    <BasicHeader />
+    <main class="w-[1440px] px-[93px] mx-auto pt-10 flex flex-col gap-8 mb-12">
+      <section class="mx-auto flex gap-4">
+        <article class="flex flex-col gap-2">
+          <button
+            class="max-h-10 px-3 py-2 border rounded flex items-center justify-center bg-black1"
+          >
+            <svg
+              width="20"
+              height="20"
+              viewBox="0 0 20 20"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M17.5 10.0003H2.5M2.5 10.0003L9.58333 2.91699M2.5 10.0003L9.58333 17.0837"
+                stroke="#202020"
+                stroke-width="2.08333"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </button>
+          <button
+            class="max-h-10 px-3 py-2 border rounded flex items-center justify-center bg-black1"
+          >
+            <svg
+              width="26"
+              height="26"
+              viewBox="0 0 26 26"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M19.25 23.417C20.9759 23.417 22.375 22.0179 22.375 20.292C22.375 18.5661 20.9759 17.167 19.25 17.167C17.5241 17.167 16.125 18.5661 16.125 20.292C16.125 22.0179 17.5241 23.417 19.25 23.417Z"
+                stroke="#202020"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+              <path
+                d="M19.25 8.83301C20.9759 8.83301 22.375 7.43389 22.375 5.70801C22.375 3.98212 20.9759 2.58301 19.25 2.58301C17.5241 2.58301 16.125 3.98212 16.125 5.70801C16.125 7.43389 17.5241 8.83301 19.25 8.83301Z"
+                stroke="#202020"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+              <path
+                d="M6.75 16.125C8.47589 16.125 9.875 14.7259 9.875 13C9.875 11.2741 8.47589 9.875 6.75 9.875C5.02411 9.875 3.625 11.2741 3.625 13C3.625 14.7259 5.02411 16.125 6.75 16.125Z"
+                stroke="#202020"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+              <path d="M16.6462 7.27051L9.35449 11.4372" stroke="#202020" stroke-width="2" />
+              <path d="M9.35449 14.5625L16.6462 18.7292" stroke="#202020" stroke-width="2" />
+            </svg>
+          </button>
+          <button
+            class="max-h-10 px-3 py-2 border border-primaryRed rounded flex items-center justify-center bg-black1"
+          >
+            <svg
+              width="18"
+              height="18"
+              viewBox="0 0 18 18"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M17 5.59091C17 3.33156 15.1345 1.5 12.8333 1.5C11.1128 1.5 9.63581 2.52389 9 3.98493C8.3642 2.52389 6.88722 1.5 5.16667 1.5C2.86548 1.5 1 3.33156 1 5.59091C1 12.1551 9 16.5 9 16.5C9 16.5 17 12.1551 17 5.59091Z"
+                stroke="#DC3644"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </button>
+        </article>
+        <article class="w-[620px] flex flex-col gap-8">
+          <div class="w-full h-[400px] overflow-hidden rounded-lg">
+            <img :src="DUMMY_POST.image" alt="placeholder" />
+          </div>
+          <div class="flex flex-col gap-4">
+            <h2 class="text-title font-bold dark:text-black1">{{ DUMMY_POST.title }}</h2>
+            <div class="flex items-center gap-3">
+              <span class="text-body1 text-black4">{{ DUMMY_POST.author.fullName }}</span>
+              <span class="text-body1 text-black4">|</span>
+              <span class="text-body1 text-black4">{{
+                getRelativeTime(DUMMY_POST.createdAt)
+              }}</span>
+            </div>
+          </div>
+          <hr />
+          <p
+            class="text-body1 font-light leading-8 dark:text-black1"
+            v-html="DUMMY_POST.content"
+          ></p>
+          <div class="flex items-center gap-3 px-4 py-3 bg-black2 rounded dark:bg-black8">
+            <span class="text-body1 font-bold dark:text-black1">Tags</span>
+            <span
+              v-for="tag in DUMMY_POST.tags"
+              :key="tag"
+              class="text-body2 bg-black1 text-black10 px-4 py-1 rounded dark:bg-black7 dark:text-black1"
+            >
+              {{ tag }}
+            </span>
+          </div>
+        </article>
+      </section>
+    </main>
 
+    <!-- 댓글 섹션 -->
+    <section class="w-full bg-black2 dark:bg-black8 py-8">
+      <article class="w-[1440px] mx-auto flex gap-4 items-center justify-center">
+        <div class="w-10 h-10"></div>
+        <section class="max-w-[620px] flex flex-col gap-8">
+          <CommentForm />
+          <CommentList :comments="DUMMY_POST.comments" />
+        </section>
+      </article>
+    </section>
+    <BasicFooter />
+  </div>
 </template>
 
-<style scoped>
-
-</style>
+<style scoped></style>


### PR DESCRIPTION
## 🔘Part  
- [x] FE  

<br/>  

## 🔎 작업 내용  
- `router` 라우팅 구조 개선  
- `v-application`에 `Pretendard` 폰트 설정  
- 자유게시판 게시글 상세페이지 경로 설정 및 라우트 수정  
- 댓글 UI 공용 컴포넌트 추가  
- 게시글 상세페이지 퍼블리싱  
- 글쓰기 버튼 클릭 시 페이지 이동 기능 추가  

<br/>  

## 📷 이미지 첨부  

### 자유게시판 - 상세페이지
<table>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/6e35b6a9-051e-48c1-b05c-28a68259e272"/></td>
    <td><img src="https://github.com/user-attachments/assets/91dcbfda-c797-4b40-9a5a-bd7afa290dd3"/></td>
  </tr>
</table>

### 라우터 구조 (루트별 파일 분리)
```jsx
import { createRouter, createWebHistory } from 'vue-router'
import {
  FREEBOARD_ROUTES,
  BICYCLE_ROUTES,
  USER_ROUTES,
  NEWS_ROUTES,
  QNABOARD_ROUTES,
  RIDERPARTS_ROUTES,
} from './routes'
import Main from '@/views/main/Main.vue'
import RoadMap from '@/views/roadMap/RoadMap.vue'

const router = createRouter({
  history: createWebHistory(import.meta.env.BASE_URL),
  routes: [
    {
      path: '/',
      name: 'home',
      component: Main,
    },
    {
      path: '/roadMap',
      name: 'RoadMap',
      component: RoadMap,
    },
    ...BICYCLE_ROUTES,
    ...FREEBOARD_ROUTES,
    ...NEWS_ROUTES,
    ...QNABOARD_ROUTES,
    ...RIDERPARTS_ROUTES,
    ...USER_ROUTES,
  ],
})

export default router
``` 

<br/>  

## 🔧 앞으로의 과제  
- 상세페이지 데이터 연동  
- 댓글 기능 구현 및 API 연결  

<br/>  