### PR TITLE
design: 자전거 검색 페이지 다크 모드

### DIFF
--- a/src/views/bicycle/bicycleSearch/BicycleSearch.vue
+++ b/src/views/bicycle/bicycleSearch/BicycleSearch.vue
@@ -33,23 +33,23 @@ onMounted(() => {
     <ShopHeader/>
     <div class="bg-black2 h-full dark:bg-black8">
       <div class="flex w-[1440px] px-[93px] mx-auto pt-[32px]">
-        <div class="w-1/4 rounded-lg bg-white drop-shadow-custom h-fit">
+        <div class="w-1/4 rounded-lg bg-white drop-shadow-custom h-fit dark:bg-black9">
           <div class="">
-            <div class="border-b">
+            <div class="border-b dark:border-b-black1">
               <div class="p-6">
                 <div class="flex justify-between">
-                  <p class="font-impact text-lg">선택된 옵션</p>
+                  <p class="font-impact text-lg dark:text-black1">선택된 옵션</p>
                   <svg width="16" height="16" viewBox="0 0 12 13" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <path d="M10.9441 7.25C10.5822 9.65565 8.5065 11.5 6 11.5C3.23857 11.5 1 9.2614 1 6.5C1 3.73857 3.23857 1.5 6 1.5C8.0503 1.5 9.8124 2.73409 10.5839 4.5" stroke="#979797" stroke-linecap="round" stroke-linejoin="round"/>
                     <path d="M8.5 4.5H10.7C10.8657 4.5 11 4.36568 11 4.2V2" stroke="#979797" stroke-linecap="round" stroke-linejoin="round"/>
                   </svg>
                 </div>
                 <div>
-                  <div class="flex bg-black10 rounded-full w-fit p-1 px-3">
-                    <p class="font-impact text-black1 mb-0 mr-1">메리다</p>
+                  <div class="flex bg-black10 rounded-full w-fit p-1 px-3 dark:bg-black1">
+                    <p class="font-impact text-black1 mb-0 mr-1 dark:text-black10">메리다</p>
                     <div class="mt-1">
                       <svg width="16" height="16" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
-                        <path d="M2.14551 9.85475L6.00038 5.9999M6.00038 5.9999L9.85524 2.14502M6.00038 5.9999L2.14551 2.14502M6.00038 5.9999L9.85524 9.85475" class="stroke-black1 pt-2" stroke-linecap="round" stroke-linejoin="round"/>
+                        <path d="M2.14551 9.85475L6.00038 5.9999M6.00038 5.9999L9.85524 2.14502M6.00038 5.9999L2.14551 2.14502M6.00038 5.9999L9.85524 9.85475" class="stroke-black1 pt-2 dark:stroke-black10" stroke-linecap="round" stroke-linejoin="round"/>
                       </svg>
                     </div>
                   </div>
@@ -57,9 +57,9 @@ onMounted(() => {
               </div>
             </div>
 
-            <div class="border-b">
+            <div class="border-b dark:border-b-black1">
               <div class="p-6">
-                <p class="font-impact text-lg">브랜드</p>
+                <p class="font-impact text-lg dark:text-black1">브랜드</p>
                 <div class="mb-6">
                   <label class="flex h-full border-2 border-black4  rounded-lg p-2 pl-3 pr-3">
                     <!--  검색 아이콘   -->
@@ -70,9 +70,9 @@ onMounted(() => {
                     <input class="focus:outline-none dark:text-black1 ml-2" placeholder="브랜드 입력"/>
                   </label>
                 </div>
-                <div class="flex hover:bg-black2 p-2 rounded-lg">
+                <div class="flex hover:bg-black4 p-2 rounded-lg">
                   <input class="mr-2 accent-black10" type="checkbox">
-                  <p class="mb-0 font-sans">삼천리자전거</p>
+                  <p class="mb-0 font-sans dark:text-black1 hover:text-black10">삼천리자전거</p>
                 </div>
               </div>
             </div>
@@ -80,56 +80,57 @@ onMounted(() => {
 
           <div >
             <div class="p-6">
-              <p class="font-impact text-lg">카테고리</p>
-              <div class="flex hover:bg-black2 p-2 mb-2 rounded-lg">
-                <input class="mr-2 accent-black10" type="checkbox">
-                <p class="mb-0 font-sans">MTB</p>
+              <p class="font-impact text-lg dark:text-black1">카테고리</p>
+              <div class="flex hover:bg-black4 p-2 mb-2 rounded-lg">
+                <input class="mr-2 accent-black10 dark:accent-black1" type="checkbox">
+                <p class="mb-0 font-sans dark:text-black1">MTB</p>
               </div>
-              <div class="flex hover:bg-black2 p-2 mb-2 rounded-lg">
-                <input class="mr-2 accent-black10" type="checkbox">
-                <p class="mb-0 font-sans">아동용</p>
+              <div class="flex hover:bg-black4 p-2 mb-2 rounded-lg">
+                <input class="mr-2 accent-black10 dark:accent-black1" type="checkbox">
+                <p class="mb-0 font-sans dark:text-black1">아동용</p>
               </div>
-              <div class="flex hover:bg-black2 p-2 mb-2 rounded-lg">
-                <input class="mr-2 accent-black10" type="checkbox">
-                <p class="mb-0 font-sans">로드자전거</p>
+              <div class="flex hover:bg-black4 p-2 mb-2 rounded-lg">
+                <input class="mr-2 accent-black10 dark:accent-black1" type="checkbox">
+                <p class="mb-0 font-sans dark:text-black1">로드자전거</p>
               </div>
-              <div class="flex hover:bg-black2 p-2 mb-2 rounded-lg">
-                <input class="mr-2 accent-black10" type="checkbox">
-                <p class="mb-0 font-sans">하이브리드</p>
+              <div class="flex hover:bg-black4 p-2 mb-2 rounded-lg">
+                <input class="mr-2 accent-black10 dark:accent-black1" type="checkbox">
+                <p class="mb-0 font-sans dark:text-black1">하이브리드</p>
               </div>
-              <div class="flex hover:bg-black2 p-2 mb-2 rounded-lg">
-                <input class="mr-2 accent-black10" type="checkbox">
-                <p class="mb-0 font-sans">전기자전거</p>
+              <div class="flex hover:bg-black4 p-2 mb-2 rounded-lg">
+                <input class="mr-2 accent-black10 dark:accent-black1" type="checkbox">
+                <p class="mb-0 font-sans dark:text-black1">전기자전거</p>
               </div>
-              <div class="flex hover:bg-black2 p-2 mb-2 rounded-lg">
-                <input class="mr-2 accent-black10" type="checkbox">
-                <p class="mb-0 font-sans">픽시</p>
+              <div class="flex hover:bg-black4 p-2 mb-2 rounded-lg">
+                <input class="mr-2 accent-black10 dark:accent-black1" type="checkbox">
+                <p class="mb-0 font-sans dark:text-black1">픽시</p>
               </div>
             </div>
           </div>
         </div>
 
-        <div class="ml-4 bg-white w-4/5 p-4 drop-shadow-custom rounded-lg">
+        <div class="ml-4 bg-white w-4/5 p-4 drop-shadow-custom rounded-lg dark:bg-black8">
           <div class="grid grid-cols-2 gap-4">
             <div v-for="item in groupList" :key="item.id" class="flex">
               <img :src="item.image" class="border rounded-lg w-[200px] h-[200px] mr-4">
               <div>
                 <div class="flex justify-between">
-                  <p class="mb-0 font-sans">{{ item.brand }}</p>
+                  <p class="mb-0 font-sans dark:text-black1">{{ item.brand }}</p>
                   <svg width="18" height="17" viewBox="0 0 18 17" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <path d="M17 5.09091C17 2.83156 15.1345 1 12.8333 1C11.1128 1 9.63581 2.02389 9 3.48493C8.3642 2.02389 6.88722 1 5.16667 1C2.86548 1 1 2.83156 1 5.09091C1 11.6551 9 16 9 16C9 16 17 11.6551 17 5.09091Z" stroke="#2A2A2A" stroke-linecap="round" stroke-linejoin="round"/>
+                    <path d="M17 5.09091C17 2.83156 15.1345 1 12.8333 1C11.1128 1 9.63581 2.02389 9 3.48493C8.3642 2.02389 6.88722 1 5.16667 1C2.86548 1 1 2.83156 1 5.09091C1 11.6551 9 16 9 16C9 16 17 11.6551 17 5.09091Z" class="dark:stroke-black1" stroke="#2A2A2A" stroke-linecap="round" stroke-linejoin="round"/>
                   </svg>
                 </div>
-                <p class="my-[9px] font-impact truncate h-[24px] w-[220px]">{{ item.name }}</p>
+                <p class="my-[9px] font-impact truncate h-[24px] w-[220px] dark:text-black1">{{ item.name }}</p>
                 <v-rating
                   hover
                   :length="5"
                   :size="32"
                   :model-value="item.rating"
                   active-color="#DC3644"
+                  class="dark:text-black1"
                 />
-                <p class="mb-1 mt-8 font-impact">{{ item.price }}원</p>
-                <div class="rounded-full bg-black2 flex align-center text-center py-1">
+                <p class="mb-1 mt-8 font-impact dark:text-black1">{{ item.price }}원</p>
+                <div class="rounded-full bg-black3 flex align-center text-center py-1 dark:bg-black2">
                   <svg class="ml-auto" width="17" height="17" viewBox="0 0 15 16" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <path d="M10.3128 13.625H11.6683C12.4343 13.625 13.0202 12.9421 12.9037 12.1849L12.0383 6.55993C11.9445 5.95014 11.4198 5.5 10.8029 5.5H4.19769C3.58072 5.5 3.05604 5.95014 2.96222 6.55993L2.09684 12.1849C1.98034 12.9421 2.56619 13.625 3.3323 13.625H4.68779" stroke="black" stroke-linecap="round" stroke-linejoin="round"/>
                     <path d="M7.5 8V12.375M7.5 12.375L9.375 10.5M7.5 12.375L5.625 10.5" stroke="black" stroke-linecap="round" stroke-linejoin="round"/>


### PR DESCRIPTION
## 🔘Part

- [x] FE

  <br/>

## 🔎 작업 내용

- 페이지 다크 모드 적용

  <br/>

## 이미지 첨부
![screencapture-localhost-5173-bicycleSearch-2025-02-28-10_25_41](https://github.com/user-attachments/assets/5d398a92-849e-475d-8223-956d85343892)

<br/>

## 🔧 앞으로의 과제

- 자전거 디테일 페이지

  <br/>

## ➕ 이슈 링크

```html
<v-rating
        hover
        :length="5"
        :size="32"
        :model-value="item.rating"
        active-color="#DC3644"
        class="dark:text-black1" <- vuetify와 tailwind의 충돌로 적용이 된지 않는 문제가 있었음
/>
```

![스크린샷 2025-02-28 오전 10 28 56](https://github.com/user-attachments/assets/a3fab789-579e-4201-aea1-358a03da7d7a)
에디터에서 자동완성을 tailwind가 아닌 vuetify 인스턴스로 해야 적용됩니다. 
<br/>