### PR TITLE
QnaBoardPage Publishing

### DIFF
--- a/src/components/search/KeywordSearch.vue
+++ b/src/components/search/KeywordSearch.vue
@@ -1,0 +1,61 @@
+<template>
+  <article class="flex gap-4 items-stretch dark:bg-black8">
+    <div class="flex items-center gap-2 border border-black4 px-4 py-2 rounded">
+      <label for="keyword_search">
+        <svg
+          width="22"
+          height="22"
+          viewBox="0 0 22 22"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M14 14L19 19"
+            stroke="black-10"
+            class="stroke-black10 dark:stroke-black1"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+          <path
+            d="M3 9.5C3 13.0899 5.91015 16 9.5 16C11.2981 16 12.9256 15.27 14.1023 14.0901C15.275 12.9143 16 11.2918 16 9.5C16 5.91015 13.0899 3 9.5 3C5.91015 3 3 5.91015 3 9.5Z"
+            stroke="black-10"
+            class="stroke-black10 dark:stroke-black1"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        </svg>
+      </label>
+      <input
+        :value="modelValue"
+        @input="$emit('update:modelValue', $event.target.value)"
+        type="text"
+        id="keyword_search"
+        class="outline-none bg-transparent dark:caret-black1 dark:text-black1"
+        placeholder="제목, 내용, 작성자명으로 검색"
+      />
+    </div>
+    <button
+      class="w-32 font-bold bg-black8 py-4 rounded text-black1 dark:bg-black1 dark:text-black9"
+      @click="handleSearch"
+    >
+      검색
+    </button>
+  </article>
+</template>
+
+<script setup>
+const props = defineProps({
+  modelValue: {
+    type: String,
+    default: '',
+  },
+})
+
+const emit = defineEmits(['update:modelValue', 'search'])
+
+const handleSearch = () => {
+  emit('search', props.modelValue)
+}
+</script>

--- a/src/components/search/TagSearch.vue
+++ b/src/components/search/TagSearch.vue
@@ -1,0 +1,166 @@
+<template>
+  <article class="flex gap-4 items-stretch dark:bg-black8">
+    <div class="flex items-start gap-3 border border-black4 px-4 py-3 rounded">
+      <label for="tag_search" class="mt-1">
+        <svg
+          width="20"
+          height="20"
+          viewBox="0 0 20 20"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M8.33333 3.5L5 18.5"
+            stroke="black-10"
+            class="stroke-black10 dark:stroke-black1"
+            stroke-width="1.5"
+            stroke-linecap="round"
+          />
+          <path
+            d="M17.083 14.334H2.08301"
+            stroke="black-10"
+            class="stroke-black10 dark:stroke-black1"
+            stroke-width="1.5"
+            stroke-linecap="round"
+          />
+          <path
+            d="M18.333 6.83398H3.33301"
+            stroke="black-10"
+            class="stroke-black10 dark:stroke-black1"
+            stroke-width="1.5"
+            stroke-linecap="round"
+          />
+          <path
+            d="M15.0003 3.5L11.667 18.5"
+            stroke="black-10"
+            class="stroke-black10 dark:stroke-black1"
+            stroke-width="1.5"
+            stroke-linecap="round"
+          />
+        </svg>
+      </label>
+      <div class="flex flex-wrap gap-2 items-center">
+        <span
+          v-for="(tag, index) in tags"
+          :key="index"
+          class="bg-black2 text-black10 px-2 py-1 rounded dark:bg-black7 dark:text-black1"
+        >
+          {{ tag }}
+          <button @click="removeTag(index)" class="text-sm">&times;</button>
+        </span>
+        <input
+          v-model="tagInput"
+          type="text"
+          id="tag_search"
+          @keyup.enter="addTag"
+          @keydown="handleKeydown"
+          class="py-1 outline-none bg-transparent dark:caret-black1 dark:text-black1 flex-1"
+          placeholder="태그로 검색해보세요!"
+        />
+      </div>
+    </div>
+    <button
+      class="min-w-32 bg-black2 py-3 rounded text-black9 dark:bg-black7 dark:text-black1"
+      @click="resetFilters"
+    >
+      <div class="flex items-center justify-center gap-2">
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 20 20"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M17.9321 6.66797C16.6461 3.72479 13.7094 1.66797 10.2921 1.66797C5.97106 1.66797 2.4181 4.95687 2 9.16797"
+            stroke="black-10"
+            class="stroke-black10 dark:stroke-black1"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+          <path
+            d="M14.459 6.66667H18.1256C18.4018 6.66667 18.6257 6.44281 18.6257 6.16667V2.5"
+            stroke="black-10"
+            class="stroke-black10 dark:stroke-black1"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+          <path
+            d="M2.69336 13.332C3.97929 16.2752 6.91609 18.332 10.3333 18.332C14.6544 18.332 18.2074 15.0431 18.6255 10.832"
+            stroke="black-10"
+            class="stroke-black10 dark:stroke-black1"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+          <path
+            d="M6.16667 13.332H2.5C2.22386 13.332 2 13.5559 2 13.832V17.4987"
+            stroke="black-10"
+            class="stroke-black10 dark:stroke-black1"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        </svg>
+        <span class="font-bold">초기화</span>
+      </div>
+    </button>
+  </article>
+</template>
+
+<script setup>
+import { ref, watch } from 'vue'
+
+const props = defineProps({
+  modelValue: {
+    type: Array,
+    default: () => [],
+  },
+})
+
+const emit = defineEmits(['update:modelValue'])
+
+const tags = ref(props.modelValue)
+const tagInput = ref('')
+
+// modelValue가 변경될 때마다 tags를 업데이트하는 watch 추가
+watch(
+  () => props.modelValue,
+  (newValue) => {
+    tags.value = newValue
+  },
+)
+
+const addTag = () => {
+  const trimmedTag = tagInput.value.trim()
+  if (trimmedTag) {
+    // 중복 태그 체크
+    if (!tags.value.includes(trimmedTag)) {
+      const newTags = [...tags.value, trimmedTag]
+      emit('update:modelValue', newTags)
+    }
+    tagInput.value = ''
+  }
+}
+
+const removeTag = (index) => {
+  const newTags = [...tags.value]
+  newTags.splice(index, 1)
+  emit('update:modelValue', newTags)
+}
+
+const handleKeydown = (e) => {
+  if (e.key === 'Backspace' && tagInput.value === '' && tags.value.length > 0) {
+    const newTags = [...tags.value]
+    newTags.pop()
+    emit('update:modelValue', newTags)
+  }
+}
+
+const resetFilters = () => {
+  emit('update:modelValue', [])
+  tagInput.value = ''
+}
+</script>

--- a/src/router/routes/QNABOARD_ROUTES.js
+++ b/src/router/routes/QNABOARD_ROUTES.js
@@ -1,7 +1,7 @@
 import QnaBoard from '@/views/qnaBoard/QnaBoard.vue'
 import QnaBoardDetail from '@/views/qnaBoard/qnaBoardDetail/QnaBoardDetail.vue'
 import QnaBoardEdit from '@/views/qnaBoard/qnaBoardEdit/QnaBoardEdit.vue'
-
+import QnaBoardWrite from '@/views/qnaBoard/qnaBoardWrite/QnaBoardWrite.vue'
 const QNABOARD_ROUTES = [
   {
     path: '/qnaBoard',
@@ -9,14 +9,19 @@ const QNABOARD_ROUTES = [
     component: QnaBoard,
   },
   {
-    path: '/qnaBoardEdit',
-    name: 'QnaBoardEdit',
-    component: QnaBoardEdit,
-  },
-  {
-    path: '/qnaBoardDetail',
+    path: '/qnaBoard/detail/:id',
     name: 'QnaBoardDetail',
     component: QnaBoardDetail,
+  },
+  {
+    path: '/qnaBoard/write',
+    name: 'QnaBoardWrite',
+    component: QnaBoardWrite,
+  },
+  {
+    path: '/qnaBoard/edit/:id',
+    name: 'QnaBoardEdit',
+    component: QnaBoardEdit,
   },
 ]
 export default QNABOARD_ROUTES

--- a/src/views/freeBoard/FreeBoard.vue
+++ b/src/views/freeBoard/FreeBoard.vue
@@ -3,31 +3,17 @@ import BasicFooter from '@/components/BasicFooter.vue'
 import BasicHeader from '@/components/BasicHeader.vue'
 import FreeBoardListItem from './components/FreeBoardListItem.vue'
 import { ref } from 'vue'
+import KeywordSearch from '@/components/search/KeywordSearch.vue'
+import TagSearch from '@/components/search/TagSearch.vue'
 
-const tags = ref([])
-const tagInput = ref('')
 const selectedSort = ref('latest')
+const searchKeyword = ref('')
+const searchTags = ref([])
 
-const addTag = (e) => {
-  if (e.key === 'Enter' && tagInput.value.trim()) {
-    tags.value.push(tagInput.value.trim())
-    tagInput.value = ''
-  }
-}
-
-const removeTag = (index) => {
-  tags.value.splice(index, 1)
-}
-
-const handleKeydown = (e) => {
-  if (e.key === 'Backspace' && tagInput.value === '' && tags.value.length > 0) {
-    tags.value.pop()
-  }
-}
-
-const resetFilters = () => {
-  tags.value = []
-  tagInput.value = ''
+const handleSearch = () => {
+  // 검색 로직 구현
+  console.log('검색어:', searchKeyword.value)
+  console.log('태그:', searchTags.value)
 }
 
 const dummyPosts = [
@@ -117,156 +103,8 @@ const dummyPosts = [
 
       <!-- 검색 영역 -->
       <section class="flex flex-col gap-4">
-        <article class="flex gap-4 items-stretch dark:bg-black8">
-          <div class="flex items-center gap-2 border border-black4 px-4 py-3 rounded">
-            <label for="keyword_search"
-              ><svg
-                width="22"
-                height="22"
-                viewBox="0 0 22 22"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M14 14L19 19"
-                  stroke="black-10"
-                  class="stroke-black10 dark:stroke-black1"
-                  stroke-width="1.5"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                />
-                <path
-                  d="M3 9.5C3 13.0899 5.91015 16 9.5 16C11.2981 16 12.9256 15.27 14.1023 14.0901C15.275 12.9143 16 11.2918 16 9.5C16 5.91015 13.0899 3 9.5 3C5.91015 3 3 5.91015 3 9.5Z"
-                  stroke="black-10"
-                  class="stroke-black10 dark:stroke-black1"
-                  stroke-width="1.5"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                />
-              </svg>
-            </label>
-            <input
-              type="text"
-              id="keyword_search"
-              class="outline-none bg-transparent dark:caret-black1 dark:text-black1"
-              placeholder="제목, 내용, 작성자명으로 검색"
-            />
-          </div>
-          <button
-            class="w-32 font-bold bg-black8 py-4 rounded text-black1 dark:bg-black1 dark:text-black9"
-          >
-            검색
-          </button>
-        </article>
-        <article class="flex gap-4 items-stretch dark:bg-black8">
-          <div class="flex items-center gap-2 border border-black4 px-4 py-3 rounded">
-            <label for="tag_search">
-              <svg
-                width="20"
-                height="20"
-                viewBox="0 0 20 20"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M8.33333 3.5L5 18.5"
-                  stroke="black-10"
-                  class="stroke-black10 dark:stroke-black1"
-                  stroke-width="1.5"
-                  stroke-linecap="round"
-                />
-                <path
-                  d="M17.083 14.334H2.08301"
-                  stroke="black-10"
-                  class="stroke-black10 dark:stroke-black1"
-                  stroke-width="1.5"
-                  stroke-linecap="round"
-                />
-                <path
-                  d="M18.333 6.83398H3.33301"
-                  stroke="black-10"
-                  class="stroke-black10 dark:stroke-black1"
-                  stroke-width="1.5"
-                  stroke-linecap="round"
-                />
-                <path
-                  d="M15.0003 3.5L11.667 18.5"
-                  stroke="black-10"
-                  class="stroke-black10 dark:stroke-black1"
-                  stroke-width="1.5"
-                  stroke-linecap="round"
-                />
-              </svg>
-            </label>
-            <div class="flex flex-wrap gap-2 items-center">
-              <span
-                v-for="(tag, index) in tags"
-                :key="index"
-                class="bg-black2 text-black10 px-2 py-1 rounded dark:bg-black7 dark:text-black1"
-              >
-                {{ tag }}
-                <button @click="removeTag(index)" class="text-sm">&times;</button>
-              </span>
-              <input
-                v-model="tagInput"
-                type="text"
-                id="tag_search"
-                @keyup.enter="addTag"
-                @keydown="handleKeydown"
-                class="py-1 outline-none bg-transparent dark:caret-black1 dark:text-black1 flex-1"
-                placeholder="태그로 검색해보세요!"
-              />
-            </div>
-          </div>
-          <button
-            class="w-32 bg-black2 py-4 rounded text-black9 dark:bg-black7 dark:text-black1"
-            @click="resetFilters"
-          >
-            <div class="flex items-center justify-center gap-2">
-              <svg
-                width="20"
-                height="20"
-                viewBox="0 0 20 20"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M17.9321 6.66797C16.6461 3.72479 13.7094 1.66797 10.2921 1.66797C5.97106 1.66797 2.4181 4.95687 2 9.16797"
-                  stroke="black-10"
-                  class="stroke-black10 dark:stroke-black1"
-                  stroke-width="1.5"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                />
-                <path
-                  d="M14.459 6.66667H18.1256C18.4018 6.66667 18.6257 6.44281 18.6257 6.16667V2.5"
-                  stroke="black-10"
-                  class="stroke-black10 dark:stroke-black1"
-                  stroke-width="1.5"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                />
-                <path
-                  d="M2.69336 13.332C3.97929 16.2752 6.91609 18.332 10.3333 18.332C14.6544 18.332 18.2074 15.0431 18.6255 10.832"
-                  stroke="black-10"
-                  class="stroke-black10 dark:stroke-black1"
-                  stroke-width="1.5"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                />
-                <path
-                  d="M6.16667 13.332H2.5C2.22386 13.332 2 13.5559 2 13.832V17.4987"
-                  stroke="black-10"
-                  class="stroke-black10 dark:stroke-black1"
-                  stroke-width="1.5"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                />
-              </svg>
-              <span class="font-bold">초기화</span>
-            </div>
-          </button>
-        </article>
+        <KeywordSearch v-model="searchKeyword" @search="handleSearch" />
+        <TagSearch v-model="searchTags" @search="handleSearch" />
       </section>
 
       <!-- 정렬 옵션 & 글쓰기 버튼 -->

--- a/src/views/qnaBoard/QnaBoard.vue
+++ b/src/views/qnaBoard/QnaBoard.vue
@@ -1,11 +1,196 @@
 <script setup>
+import BasicHeader from '@/components/BasicHeader.vue'
+import BasicFooter from '@/components/BasicFooter.vue'
+import { ref } from 'vue'
+import QnaListItem from './components/QnaListItem.vue'
+import QnaBoardHeader from './components/QnaBoardHeader.vue'
+import QnaFilterMenu from './components/QnaFilterMenu.vue'
+import TopWriters from './components/TopWriters.vue'
+import KeywordSearch from '@/components/search/KeywordSearch.vue'
+import TagSearch from '@/components/search/TagSearch.vue'
 
+const selectedSort = ref('latest')
+const selectedFilter = ref('all')
+
+const searchKeyword = ref('')
+const searchTags = ref([])
+
+const handleKeywordSearch = (keyword) => {
+  // 검색 로직 구현
+  console.log('검색어:', keyword)
+  console.log('태그:', searchTags.value)
+}
+
+const DUMMY_QNAS = [
+  {
+    id: 1,
+    title: '리엑토5000 멕라렌 휠셋브랜드 추천',
+    content:
+      '이제 60림으로 휠셋은 정했는데 이떤 브랜드 할지 고민이네요. 아비바브가 어울려보이기 한데 다른 브랜드도 있나요?',
+    tags: ['휠셋', '멕라렌', '아비바브', '브랜드'],
+    author: {
+      fullName: '감자머리',
+      profileImage: 'https://placehold.co/50x50',
+    },
+    createdAt: '2025-02-27',
+    comments: [
+      {
+        content: '네, 아비바브가 어울려보이기 한데 다른 브랜드도 있나요?',
+        author: {
+          fullName: 'John Doe',
+          profileImage: 'https://placehold.co/50x50',
+        },
+        createdAt: '2025-02-27',
+      },
+    ],
+    views: 72,
+    like: 100,
+    isSolved: false,
+  },
+  {
+    id: 2,
+    title: '자전거 프레임 사이즈 고민입니다',
+    content: '키 175cm인데 54사이즈와 56사이즈 중 고민이에요. 어떤 걸 선택하는 게 좋을까요?',
+    tags: ['프레임', '사이즈', '초보'],
+    author: {
+      fullName: '바이크러버',
+      profileImage: 'https://placehold.co/50x50',
+    },
+    createdAt: '2025-02-26',
+    comments: [],
+    views: 45,
+    like: 23,
+    isSolved: true,
+  },
+  {
+    id: 3,
+    title: '첫 로드바이크 구매 조언 부탁드립니다',
+    content: '예산 300만원으로 첫 로드바이크 구매하려고 합니다. 추천 부탁드려요!',
+    tags: ['구매', '로드바이크', '입문'],
+    author: {
+      fullName: '뉴비라이더',
+      profileImage: 'https://placehold.co/50x50',
+    },
+    createdAt: '2025-02-25',
+    comments: [],
+    views: 128,
+    like: 56,
+    isSolved: false,
+  },
+  {
+    id: 4,
+    title: '클리트 위치 조정 문의',
+    content: '페달링 시 무릎 통증이 있는데 클리트 위치 조정이 필요할까요?',
+    tags: ['클리트', '페달링', '자세'],
+    author: {
+      fullName: '라이딩고수',
+      profileImage: 'https://placehold.co/50x50',
+    },
+    createdAt: '2025-02-24',
+    comments: [],
+    views: 89,
+    like: 34,
+    isSolved: true,
+  },
+  {
+    id: 5,
+    title: '겨울철 라이딩 장비 추천',
+    content: '겨울철 라이딩을 위한 필수 장비 추천 부탁드립니다.',
+    tags: ['겨울라이딩', '장비', '의류'],
+    author: {
+      fullName: '동계라이더',
+      profileImage: 'https://placehold.co/50x50',
+    },
+    createdAt: '2025-02-23',
+    comments: [],
+    views: 156,
+    like: 78,
+    isSolved: false,
+  },
+]
+
+const DUMMY_WRITERS = [
+  {
+    id: 1,
+    fullName: '신짱구',
+    profileImage: 'https://placehold.co/50x50',
+    postCount: 20,
+  },
+  {
+    id: 2,
+    fullName: '김철수',
+    profileImage: 'https://placehold.co/50x50',
+    postCount: 15,
+  },
+  {
+    id: 3,
+    fullName: '한유리',
+    profileImage: 'https://placehold.co/50x50',
+    postCount: 10,
+  },
+]
 </script>
 
 <template>
+  <div class="w-full block h-full dark:bg-black9">
+    <BasicHeader />
+    <QnaBoardHeader />
+    <section class="w-[1440px] px-[198px] mx-auto pt-10 grid grid-cols-10 gap-6 mb-12 items-start">
+      <!-- 질문 게시판 - 좌측 영역 -->
+      <article class="col-span-2 flex flex-col gap-4">
+        <QnaFilterMenu v-model="selectedFilter" />
+        <TopWriters :writers="DUMMY_WRITERS" />
+      </article>
 
+      <!-- 질문 게시판 - 가운데 영역 -->
+      <article class="col-span-6 flex flex-col gap-6">
+        <!-- 검색 영역 -->
+        <section class="flex flex-col gap-4">
+          <KeywordSearch v-model="searchKeyword" @search="handleKeywordSearch" />
+          <TagSearch v-model="searchTags" />
+        </section>
+
+        <!-- 정렬 옵션 & 글쓰기 버튼 -->
+        <section class="flex items-center justify-between">
+          <div class="flex gap-4 text-sub-body1">
+            <button
+              class="text-black10 dark:text-black1"
+              :class="{ 'font-bold': selectedSort === 'latest' }"
+              @click="selectedSort = 'latest'"
+            >
+              최신순
+            </button>
+            <button
+              class="text-black10 dark:text-black1"
+              :class="{ 'font-bold': selectedSort === 'popular' }"
+              @click="selectedSort = 'popular'"
+            >
+              인기순
+            </button>
+            <button
+              class="text-black10 dark:text-black1"
+              :class="{ 'font-bold': selectedSort === 'views' }"
+              @click="selectedSort = 'views'"
+            >
+              조회순
+            </button>
+          </div>
+          <router-link to="/qnaBoard/write" class="bg-black6 px-6 py-2 rounded text-black1"
+            >글쓰기</router-link
+          >
+        </section>
+
+        <!-- 질문 게시판 목록 -->
+        <ul class="flex flex-col list-none p-0 items-start">
+          <QnaListItem v-for="qna in DUMMY_QNAS" :key="qna.id" :qna="qna" />
+        </ul>
+      </article>
+
+      <!-- 질문 게시판 - 우측 영역 -->
+      <article class="col-span-2"></article>
+    </section>
+    <BasicFooter />
+  </div>
 </template>
 
-<style scoped>
-
-</style>
+<style scoped></style>

--- a/src/views/qnaBoard/QnaBoard.vue
+++ b/src/views/qnaBoard/QnaBoard.vue
@@ -8,6 +8,7 @@ import QnaFilterMenu from './components/QnaFilterMenu.vue'
 import TopWriters from './components/TopWriters.vue'
 import KeywordSearch from '@/components/search/KeywordSearch.vue'
 import TagSearch from '@/components/search/TagSearch.vue'
+import PopularTags from './components/PopularTags.vue'
 
 const selectedSort = ref('latest')
 const selectedFilter = ref('all')
@@ -187,7 +188,9 @@ const DUMMY_WRITERS = [
       </article>
 
       <!-- 질문 게시판 - 우측 영역 -->
-      <article class="col-span-2"></article>
+      <article class="col-span-2">
+        <PopularTags />
+      </article>
     </section>
     <BasicFooter />
   </div>

--- a/src/views/qnaBoard/components/PopularTags.vue
+++ b/src/views/qnaBoard/components/PopularTags.vue
@@ -1,0 +1,18 @@
+<template>
+  <div class="flex flex-col gap-4 border border-black4 rounded-lg px-4 py-3">
+    <h3 class="text-body1 font-bold dark:text-black3">인기 태그</h3>
+    <div class="flex flex-wrap gap-2">
+      <span
+        v-for="tag in tags"
+        :key="tag"
+        class="text-body2 bg-black2 text-black10 px-4 py-1 rounded dark:bg-black7 dark:text-black1"
+      >
+        {{ tag }}
+      </span>
+    </div>
+  </div>
+</template>
+
+<script setup>
+const tags = ['휠셋', '브랜드 추천', '자전거', '헬멧']
+</script>

--- a/src/views/qnaBoard/components/QnaBoardHeader.vue
+++ b/src/views/qnaBoard/components/QnaBoardHeader.vue
@@ -1,0 +1,10 @@
+<template>
+  <section class="w-full bg-black2 dark:bg-black7">
+    <div class="w-[1440px] px-[198px] mx-auto py-6 flex gap-3 flex-col items-baseline">
+      <h2 class="text-title font-bold dark:text-black3">묻고 답해요</h2>
+      <p class="text-sub-title dark:text-black3 m-0">자전거 타다 궁금한 점? 여기서 해결하세요!</p>
+    </div>
+  </section>
+</template>
+
+<script setup></script>

--- a/src/views/qnaBoard/components/QnaFilterMenu.vue
+++ b/src/views/qnaBoard/components/QnaFilterMenu.vue
@@ -1,0 +1,40 @@
+<template>
+  <div class="flex flex-col gap-4 font-light">
+    <span
+      class="text-sub-title cursor-pointer"
+      :class="{ 'font-bold text-primaryRed dark:text-primaryRed': selectedFilter === 'all' }"
+      @click="emit('update:modelValue', 'all')"
+    >
+      전체
+    </span>
+    <span
+      class="text-sub-title dark:text-black1 cursor-pointer"
+      :class="{ 'font-bold text-primaryRed dark:text-primaryRed': selectedFilter === 'solved' }"
+      @click="emit('update:modelValue', 'solved')"
+    >
+      해결
+    </span>
+    <span
+      class="text-sub-title dark:text-black1 cursor-pointer"
+      :class="{ 'font-bold text-primaryRed dark:text-primaryRed': selectedFilter === 'unsolved' }"
+      @click="emit('update:modelValue', 'unsolved')"
+    >
+      미해결
+    </span>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  modelValue: {
+    type: String,
+    required: true,
+  },
+})
+
+const emit = defineEmits(['update:modelValue'])
+
+const selectedFilter = computed(() => props.modelValue)
+</script>

--- a/src/views/qnaBoard/components/QnaListItem.vue
+++ b/src/views/qnaBoard/components/QnaListItem.vue
@@ -10,7 +10,10 @@ defineProps({
 </script>
 
 <template>
-  <li class="w-full flex flex-col gap-6 items-start py-8 border-t border-black3 dark:border-black6">
+  <router-link
+    :to="`/qnaBoard/detail/${qna.id}`"
+    class="w-full flex flex-col gap-6 items-start py-8 border-t border-black3 dark:border-black6"
+  >
     <!-- 질문 정보 상단 -->
     <div class="flex flex-col gap-4">
       <div class="flex gap-4 items-center">
@@ -144,5 +147,5 @@ defineProps({
         >
       </div>
     </div>
-  </li>
+  </router-link>
 </template>

--- a/src/views/qnaBoard/components/QnaListItem.vue
+++ b/src/views/qnaBoard/components/QnaListItem.vue
@@ -1,0 +1,148 @@
+<script setup>
+import getRelativeTime from '@/utils/getRelativeTime'
+
+defineProps({
+  qna: {
+    type: Object,
+    required: true,
+  },
+})
+</script>
+
+<template>
+  <li class="w-full flex flex-col gap-6 items-start py-8 border-t border-black3 dark:border-black6">
+    <!-- 질문 정보 상단 -->
+    <div class="flex flex-col gap-4">
+      <div class="flex gap-4 items-center">
+        <span class="text-body1 px-4 py-1 rounded-full bg-black2 dark:bg-black7 dark:text-black1">{{
+          qna.isSolved ? '해결' : '미해결'
+        }}</span>
+        <span class="text-sub-title font-bold dark:text-black1">{{ qna.title }}</span>
+      </div>
+      <p class="text-body1 font-light m-0 dark:text-black3">
+        {{ qna.content }}
+      </p>
+      <div class="flex items-center gap-3">
+        <span
+          v-for="tag in qna.tags"
+          :key="tag"
+          class="text-body2 bg-black2 text-black10 px-4 py-1 rounded dark:bg-black7 dark:text-black1"
+        >
+          {{ tag }}
+        </span>
+      </div>
+    </div>
+    <!-- 질문 정보 하단 -->
+    <div class="flex items-center justify-between w-full">
+      <!-- 작성자 정보 & 작성일 -->
+      <div class="flex items-center gap-3">
+        <span class="text-body2 text-black5 font-light dark:text-black4">{{
+          qna.author.fullName
+        }}</span>
+        <span class="text-body2 text-black5 font-light dark:text-black4">|</span>
+        <span class="text-body2 text-black5 font-light dark:text-black4">{{
+          getRelativeTime(qna.createdAt)
+        }}</span>
+      </div>
+      <!-- 좋아요 수 & 조회수 -->
+      <div class="flex items-center gap-6 grow-0">
+        <span class="text-body2 dark:text-black3 font-light flex items-center gap-1">
+          <svg
+            width="16"
+            height="17"
+            viewBox="0 0 16 17"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M10.9813 13.8328H2.73301C2.51209 13.8328 2.33301 13.6537 2.33301 13.4328V6.89942C2.33301 6.67851 2.51209 6.49942 2.73301 6.49942H4.57809C5.04644 6.49942 5.48045 6.25369 5.72141 5.85208L7.52834 2.8405C7.91828 2.19068 8.83661 2.1289 9.31001 2.72066C9.53314 2.99959 9.60508 3.37032 9.50241 3.71246L8.82081 5.98448C8.74381 6.24113 8.93601 6.49942 9.20394 6.49942H12.254C13.1331 6.49942 13.7717 7.33542 13.5403 8.18356L12.2676 12.8502C12.1094 13.4304 11.5825 13.8328 10.9813 13.8328Z"
+              stroke="black"
+              stroke-linecap="round"
+              class="stroke-black5 dark:stroke-black1"
+            />
+            <path
+              d="M4.66699 13.8333V6.5"
+              stroke="black"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              class="stroke-black5 dark:stroke-black1"
+            />
+          </svg>
+          {{ qna.like }}</span
+        >
+        <span class="text-body2 dark:text-black3 font-light flex items-center gap-1">
+          <svg
+            width="16"
+            height="17"
+            viewBox="0 0 16 17"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M11.3333 8.83268C11.5174 8.83268 11.6667 8.68342 11.6667 8.49935C11.6667 8.31528 11.5174 8.16602 11.3333 8.16602C11.1493 8.16602 11 8.31528 11 8.49935C11 8.68342 11.1493 8.83268 11.3333 8.83268Z"
+              fill="black"
+              stroke="black"
+              stroke-width="1.125"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              class="stroke-black5 dark:stroke-black1"
+            />
+            <path
+              d="M8.00033 8.83268C8.18439 8.83268 8.33366 8.68342 8.33366 8.49935C8.33366 8.31528 8.18439 8.16602 8.00033 8.16602C7.81626 8.16602 7.66699 8.31528 7.66699 8.49935C7.66699 8.68342 7.81626 8.83268 8.00033 8.83268Z"
+              fill="black"
+              stroke="black"
+              stroke-width="1.125"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              class="stroke-black5 dark:stroke-black1"
+            />
+            <path
+              d="M4.66634 8.83268C4.85043 8.83268 4.99967 8.68342 4.99967 8.49935C4.99967 8.31528 4.85043 8.16602 4.66634 8.16602C4.48225 8.16602 4.33301 8.31528 4.33301 8.49935C4.33301 8.68342 4.48225 8.83268 4.66634 8.83268Z"
+              fill="black"
+              stroke="black"
+              stroke-width="1.125"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              class="stroke-black5 dark:stroke-black1"
+            />
+            <path
+              d="M7.99967 15.1673C11.6815 15.1673 14.6663 12.1825 14.6663 8.50065C14.6663 4.81875 11.6815 1.83398 7.99967 1.83398C4.31777 1.83398 1.33301 4.81875 1.33301 8.50065C1.33301 9.71492 1.65765 10.8534 2.22489 11.834L1.66634 14.834L4.66634 14.2755C5.64692 14.8427 6.78541 15.1673 7.99967 15.1673Z"
+              stroke="black"
+              stroke-width="1.125"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              class="stroke-black5 dark:stroke-black1"
+            />
+          </svg>
+          {{ qna.comments.length }}</span
+        >
+        <span class="text-body2 dark:text-black3 font-light flex items-center gap-1">
+          <svg
+            width="19"
+            height="19"
+            viewBox="0 0 19 19"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M1.61226 9.75492C1.55763 9.59072 1.55763 9.41324 1.61226 9.24904C2.71031 5.94542 5.8271 3.5625 9.50043 3.5625C13.1722 3.5625 16.2874 5.94304 17.3878 9.24508C17.4432 9.40896 17.4432 9.58629 17.3878 9.75096C16.2906 13.0546 13.1738 15.4375 9.50043 15.4375C5.82868 15.4375 2.71268 13.057 1.61226 9.75492Z"
+              stroke="black"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              class="stroke-black5 dark:stroke-black1"
+            />
+            <path
+              d="M11.875 9.5C11.875 10.1299 11.6248 10.734 11.1794 11.1794C10.734 11.6248 10.1299 11.875 9.5 11.875C8.87011 11.875 8.26602 11.6248 7.82062 11.1794C7.37522 10.734 7.125 10.1299 7.125 9.5C7.125 8.87011 7.37522 8.26602 7.82062 7.82062C8.26602 7.37522 8.87011 7.125 9.5 7.125C10.1299 7.125 10.734 7.37522 11.1794 7.82062C11.6248 8.26602 11.875 8.87011 11.875 9.5Z"
+              stroke="black"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              class="stroke-black5 dark:stroke-black1"
+            />
+          </svg>
+
+          {{ qna.views }}</span
+        >
+      </div>
+    </div>
+  </li>
+</template>

--- a/src/views/qnaBoard/components/TopWriters.vue
+++ b/src/views/qnaBoard/components/TopWriters.vue
@@ -1,0 +1,34 @@
+<template>
+  <div class="flex flex-col gap-4 border border-black4 rounded-lg px-4 py-3">
+    <h3 class="text-body1 font-bold dark:text-black3">RideOn Top Writters</h3>
+    <div class="flex flex-col gap-2">
+      <ul class="flex flex-col gap-2 list-none p-0">
+        <li v-for="writer in writers" :key="writer.id" class="flex gap-2 items-center">
+          <div class="flex gap-2 items-center">
+            <div class="w-5 h-5 rounded-full overflow-hidden">
+              <img
+                :src="writer.profileImage"
+                :alt="writer.fullName"
+                class="w-full h-full object-cover"
+              />
+            </div>
+            <span class="text-body1 font-light dark:text-black3">{{ writer.fullName }}</span>
+          </div>
+          <span class="text-body2 text-black5 font-light dark:text-black3">{{
+            writer.postCount
+          }}</span>
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>
+
+<script setup>
+defineProps({
+  writers: {
+    type: Array,
+    required: true,
+    default: () => [],
+  },
+})
+</script>

--- a/src/views/qnaBoard/qnaBoardDetail/QnaBoardDetail.vue
+++ b/src/views/qnaBoard/qnaBoardDetail/QnaBoardDetail.vue
@@ -1,11 +1,16 @@
 <script setup>
-
+import BasicHeader from '@/components/BasicHeader.vue'
+import BasicFooter from '@/components/BasicFooter.vue'
 </script>
 
 <template>
-
+  <div class="w-full block h-full dark:bg-black9">
+    <BasicHeader />
+    <main class="w-[1440px] px-[93px] mx-auto pt-10 flex flex-col gap-8 mb-12">
+      <h2 class="text-title font-bold text-black9 dark:text-black1">질문 작성</h2>
+    </main>
+    <BasicFooter />
+  </div>
 </template>
 
-<style scoped>
-
-</style>
+<style scoped></style>

--- a/src/views/qnaBoard/qnaBoardWrite/QnaBoardWrite.vue
+++ b/src/views/qnaBoard/qnaBoardWrite/QnaBoardWrite.vue
@@ -1,0 +1,16 @@
+<script setup>
+import BasicHeader from '@/components/BasicHeader.vue'
+import BasicFooter from '@/components/BasicFooter.vue'
+</script>
+
+<template>
+  <div class="w-full block h-full dark:bg-black9">
+    <BasicHeader />
+    <main class="w-[1440px] px-[93px] mx-auto pt-10 flex flex-col gap-8 mb-12">
+      <h2 class="text-title font-bold text-black9 dark:text-black1">질문 작성</h2>
+    </main>
+    <BasicFooter />
+  </div>
+</template>
+
+<style scoped></style>


### PR DESCRIPTION
### feat: 자유·질문 게시판 검색 및 질문 게시판 UI 추가  

## 🔘Part  
- [x] FE  

<br/>  

## 🔎 작업 내용  
- 자유·질문 게시판 공용 검색 컴포넌트 제작  
- 자유게시판 검색 바를 컴포넌트로 변경  
- 질문 게시판 `Header` 컴포넌트 추가  
- 질문 게시판 좌측 필터 메뉴 및 상위 작성자 컴포넌트 제작  
- 질문 게시판 목록 아이템 컴포넌트 제작  
- 질문 게시판 메인 페이지 퍼블리싱  
- 질문 작성 페이지 라우팅 추가 및 연결  
- 질문 게시판 우측 인기 태그 섹션 추가  
- 질문 상세 페이지 레이아웃 세팅 및 라우트 연결  

<br/>  

## 이미지 첨부  
<table>  
  <tr>  
    <td><img src="https://github.com/user-attachments/assets/2019eb20-f68d-4537-a080-afb0fdd76366" /></td>  
    <td><img src="https://github.com/user-attachments/assets/0501625e-bee6-4250-8bcf-8de4fe4d742b" /></td>  
  </tr>  
</table>  



<br/>  

## 🔧 앞으로의 과제  
- 검색 기능 구현 및 데이터 연동  
- 질문 상세페이지 기능 추가  
