### PR TITLE
feat: RiderParts 1-5 구현

### DIFF
--- a/src/apis/naverSearchApi.js
+++ b/src/apis/naverSearchApi.js
@@ -1,14 +1,15 @@
-const naverURL = import.meta.env.VITE_NAVER_SHOPPING_BASE_URL;
+// const naverURL = import.meta.env.VITE_NAVER_SHOPPING_BASE_URL;
+const naverURL = "/naver-api"
 const naverID = import.meta.env.VITE_NAVER_SHOPPING_CLIENT_ID;
 const naverSecret = import.meta.env.VITE_NAVER_SHOPPING_CLIENT_SECRET;
 import axios from "axios";
+
+console.log("✅ NAVER CLIENT ID:", import.meta.env.VITE_NAVER_SHOPPING_CLIENT_ID);
+console.log("✅ NAVER CLIENT SECRET:", import.meta.env.VITE_NAVER_SHOPPING_CLIENT_SECRET);
+
 const naverShoppingApi = axios.create({
   baseURL: naverURL,
   timeout: 5000,
-  headers: {
-    'X-Naver-Client-Id': naverID,
-    'X-Naver-Client-Secret': naverSecret,
-  },
 });
 
 export async function getNaverItems(targetWord) {
@@ -17,6 +18,10 @@ export async function getNaverItems(targetWord) {
       params: {
         query: targetWord,
         display: 20,
+      },
+      headers: {  // ✅ headers를 개별 요청에 추가
+        'X-Naver-Client-Id': naverID,
+        'X-Naver-Client-Secret': naverSecret,
       },
     });
     console.log('API 응답 데이터:', response.data);

--- a/src/views/riderParts/RiderParts.vue
+++ b/src/views/riderParts/RiderParts.vue
@@ -220,7 +220,7 @@ onMounted(() => {
               <img :src="item.image" alt="Bike Image" class="w-[302px] h-[302px] object-cover border mx-auto">
               <p class="text-sm font-sans mb-1 mt-1 text-left">{{ item.mallName }}</p>
               <p class="font-impact text-left mb-2 ellipsis-multiline">{{ item.cleanTitle }}</p>
-              <p class="font-impact text-left">{{ item.lprice }}원</p>
+              <p class="font-impact text-left">{{ item.lprice ? Number(item.lprice).toLocaleString("ko-KR") + "원" : "가격 없음" }}</p>
             </div>
           </swiper-slide>
         </swiper>

--- a/vite.config.js
+++ b/vite.config.js
@@ -15,14 +15,15 @@ export default defineConfig({
       '@': fileURLToPath(new URL('./src', import.meta.url))
     },
   },
-  // server: {
-  //   proxy: {
-  //     "/naver-api": {
-  //       target: "https://openapi.naver.com",
-  //       changeOrigin: true,
-  //       secure: true,
-  //       rewrite: (path) => path.replace(/^\/naver-api/, ""),
-  //     },
-  //   },
-  // }, 프록시 이슈 해결중
+  server: {
+    proxy: {
+      "/naver-api": {
+        target: "https://openapi.naver.com",
+        changeOrigin: true,
+        secure: true,
+        rewrite: (path) => path.replace(/^\/naver-api/, ""),
+      },
+    },
+  },
+
 })


### PR DESCRIPTION
- 제목 : feat: RiderParts 하단 레이아웃 구현


## 🔘Part

- [x] FE

  <br/>

## 🔎 작업 내용

- 네이버 CORS 에러 해결하고 하단레이아웃 구현했습니다.
- 가격 3자리 수 단위로 쉼표를 넣었습니다.

  <br/>

## 이미지 첨부

![스크린샷 2025-03-04 173645](https://github.com/user-attachments/assets/fc3d9681-ac3d-406a-a86c-7d1a00dbb442)
![스크린샷 2025-03-04 175032](https://github.com/user-attachments/assets/f8892f31-3f62-496f-812e-0738f661c45f)

<br/>

## 🔧 앞으로의 과제

- 메인페이지 페이지네이션 구현 
-  상세페이지 구현

  <br/>

## ➕ 이슈 링크


<br/>