### PR TITLE
feat: RiderPartsSearch 더보기 버튼 수정

### DIFF
--- a/src/apis/naverSearchApi.js
+++ b/src/apis/naverSearchApi.js
@@ -9,12 +9,12 @@ const naverShoppingApi = axios.create({
   timeout: 5000,
 });
 
-export async function getNaverItems(targetWord) {
+export async function getNaverItems(targetWord, displayCount = 32) {
   try {
     const response = await naverShoppingApi.get('/v1/search/shop.json', {
       params: {
         query: targetWord,
-        display: 32,
+        display: displayCount,
       },
       headers: {
         'X-Naver-Client-Id': naverID,

--- a/src/views/riderParts/roaderSearch/RiderPartSearch.vue
+++ b/src/views/riderParts/roaderSearch/RiderPartSearch.vue
@@ -37,7 +37,7 @@ const loadMore = () => {
 };
 
 onMounted(async () => {
-  items.value = await getNaverItems("자전거부품");
+  items.value = await getNaverItems("자전거부품", 81);
   visibleItems.value = cleanedItems.value.slice(0, itemsPerPage);
 });
 </script>
@@ -132,7 +132,7 @@ onMounted(async () => {
           />
         <p class="flex-grow-0 flex-shrink-0 text-base text-left text-black pt-4  dark:bg-black9">
           <span class="flex-grow-0 flex-shrink-0 text-base font-light text-left dark:text-black1">검색된 상품 </span>
-          <span class="flex-grow-0 flex-shrink-0 text-base font-semibold text-left dark:text-black1">{{ items.length }}</span>
+          <span class="flex-grow-0 flex-shrink-0 text-base font-semibold text-left dark:text-black1">{{ visibleItems.length }}</span>
           <span class="flex-grow-0 flex-shrink-0 text-base font-light text-left dark:text-black1">개</span>
         </p>
       </div>
@@ -172,15 +172,16 @@ onMounted(async () => {
           </div>
       </div>
       <!-- 더보기 -->
-      <div
+      <div class="p-[40px] flex items-center justify-center">
+        <div
         v-if="visibleItems.length < items.length"
         @click="loadMore"
-        class="flex justify-center items-center flex-grow-0 flex-shrink-0 w-[300px] relative gap-8 p-4 rounded bg-[#202020] mt-[32px] mx-[478px] cursor-pointer hover:bg-[#303030] transition-all dark:bg-black9"
+        class="flex justify-center items-center flex-grow-0 flex-shrink-0 w-[300px] h-[56px] relative gap-8 p-4 rounded-[4px] bg-black9 mt-[32px] mx-[478px] cursor-pointer hover:bg-[#303030] transition-all dark:bg-black1"
       >
-        <p class="flex-grow-0 flex-shrink-0 text-xl font-bold text-center text-white">
+        <p class="flex-grow-0 flex-shrink-0 text-xl font-bold text-center text-white dark:text-black10 pt-3">
           더보기
         </p>
-      </div>
+      </div></div>
     </div>
     <BasicFooter/>
   </div>


### PR DESCRIPTION
- 제목 : feat: RiderPartsSearch 더보기 버튼 수정

## 🔘Part

- [x] FE

  <br/>

## 🔎 작업 내용

- 더보기 버튼 디자인 수정 더보기 버튼이 없어지더라도 footer랑 일정한 거리를 유지하도록 설정, 더보기 버튼 다크모드 적용
- 서치페이지에서만 api로 데이터 받아오는 갯수를 81개로 수정
- 검색된 상품 갯수 화면에 표시된 갯수만큼만 표시되게 수정
  <br/>

## 이미지 첨부
![image](https://github.com/user-attachments/assets/a46ef45e-142a-4b6f-ac3f-809320a82026)
![image](https://github.com/user-attachments/assets/ac792992-1734-4104-80b7-60eb615c354d)
![image](https://github.com/user-attachments/assets/5b895223-00c5-408f-8216-3faef2578257)

<br/>

## 🔧 앞으로의 과제

- 정렬 구현
- 상품클릭하면 해당 디테일페이지로 이동하게 라우터 수정, 
- 메인페이지에서 헬멧 사진 누르면 헬멧누르면 서치페이지에서 헬멧으로 검색된 화면이 출력되도록 구현
  <br/>

## ➕ 이슈 링크


<br/>