### PR TITLE
Bicycle MainPage CSS Style Change

### DIFF
--- a/src/components/BasicHeader.vue
+++ b/src/components/BasicHeader.vue
@@ -94,21 +94,21 @@ watchEffect(() => {
             viewBox="0 0 25 26"
             fill="none"
             xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M6 22.1663V21.1247C6 17.0976 9.26459 13.833 13.2917 13.833C17.3187 13.833 20.5833 17.0976 20.5833 21.1247V22.1663"
-            stroke="black"
-            stroke-width="2.08333"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          />
-          <path
-            d="M13.2917 13.8333C15.5928 13.8333 17.4583 11.9678 17.4583 9.66667C17.4583 7.36548 15.5928 5.5 13.2917 5.5C10.9905 5.5 9.125 7.36548 9.125 9.66667C9.125 11.9678 10.9905 13.8333 13.2917 13.8333Z"
-            stroke="black"
-            stroke-width="2.08333"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          />
+          >
+            <path
+              d="M6 22.1663V21.1247C6 17.0976 9.26459 13.833 13.2917 13.833C17.3187 13.833 20.5833 17.0976 20.5833 21.1247V22.1663"
+              stroke="black"
+              stroke-width="2.08333"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+            <path
+              d="M13.2917 13.8333C15.5928 13.8333 17.4583 11.9678 17.4583 9.66667C17.4583 7.36548 15.5928 5.5 13.2917 5.5C10.9905 5.5 9.125 7.36548 9.125 9.66667C9.125 11.9678 10.9905 13.8333 13.2917 13.8333Z"
+              stroke="black"
+              stroke-width="2.08333"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
           </svg>
         </router-link>
       </div>
@@ -154,28 +154,28 @@ watchEffect(() => {
 
         <!-- userIcon  -->
         <router-link to="/mypage">
-        <svg
-          width="25"
-          height="26"
-          viewBox="0 0 25 26"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M6 22.1663V21.1247C6 17.0976 9.26459 13.833 13.2917 13.833C17.3187 13.833 20.5833 17.0976 20.5833 21.1247V22.1663"
-            stroke="white"
-            stroke-width="2.08333"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          />
-          <path
-            d="M13.2917 13.8333C15.5928 13.8333 17.4583 11.9678 17.4583 9.66667C17.4583 7.36548 15.5928 5.5 13.2917 5.5C10.9905 5.5 9.125 7.36548 9.125 9.66667C9.125 11.9678 10.9905 13.8333 13.2917 13.8333Z"
-            stroke="white"
-            stroke-width="2.08333"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          />
-        </svg>
+          <svg
+            width="25"
+            height="26"
+            viewBox="0 0 25 26"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M6 22.1663V21.1247C6 17.0976 9.26459 13.833 13.2917 13.833C17.3187 13.833 20.5833 17.0976 20.5833 21.1247V22.1663"
+              stroke="white"
+              stroke-width="2.08333"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+            <path
+              d="M13.2917 13.8333C15.5928 13.8333 17.4583 11.9678 17.4583 9.66667C17.4583 7.36548 15.5928 5.5 13.2917 5.5C10.9905 5.5 9.125 7.36548 9.125 9.66667C9.125 11.9678 10.9905 13.8333 13.2917 13.8333Z"
+              stroke="white"
+              stroke-width="2.08333"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
         </router-link>
       </div>
     </div>
@@ -188,6 +188,9 @@ watchEffect(() => {
       </router-link>
       <router-link to="/roadMap">
         <p class="font-bold dark:text-black1">자전거 도로</p>
+      </router-link>
+      <router-link to="/riderCrewBoard">
+        <p class="font-bold dark:text-black1">라이더 크루</p>
       </router-link>
       <router-link to="/freeBoard">
         <p class="font-bold dark:text-black1">자유게시판</p>

--- a/src/components/ShopHeader.vue
+++ b/src/components/ShopHeader.vue
@@ -1,8 +1,8 @@
 <script setup>
 import { ref, onMounted, watchEffect } from 'vue'
-const props = defineProps(['searchValue']);
+const props = defineProps(['searchValue'])
 const emits = defineEmits(['update:receiveHandler'])
-const value = ref("");
+const value = ref('')
 // 현재 테마 상태
 const isDarkMode = ref(localStorage.getItem('theme') === 'dark')
 
@@ -20,7 +20,7 @@ const toggleDarkMode = () => {
 
 // 페이지가 로드될 때 설정 확인
 onMounted(() => {
-  value.value = props.searchValue;
+  value.value = props.searchValue
   if (localStorage.getItem('theme') === 'dark') {
     document.documentElement.classList.add('dark')
     isDarkMode.value = true
@@ -59,6 +59,9 @@ watchEffect(() => {
         </router-link>
         <router-link to="/roadMap">
           <p class="font-bold text-black5">자전거 도로</p>
+        </router-link>
+        <router-link to="/riderCrewBoard">
+          <p class="font-bold text-black5">라이더 크루</p>
         </router-link>
         <router-link to="/freeBoard">
           <p class="font-bold text-black5">자유게시판</p>
@@ -153,7 +156,12 @@ watchEffect(() => {
           <label
             class="flex ml-6 w-[540px] justify-between h-full border !border-primaryRed rounded-lg p-2 pl-4 pr-4"
           >
-            <input class="focus:outline-none dark:text-black1" placeholder="Search" v-model="value" @change="emits('update:receiveHandler', value)"/>
+            <input
+              class="focus:outline-none dark:text-black1"
+              placeholder="Search"
+              v-model="value"
+              @change="emits('update:receiveHandler', value)"
+            />
             <!--  검색 아이콘   -->
             <svg
               v-if="!isDarkMode"

--- a/src/components/search/LocationFilter.vue
+++ b/src/components/search/LocationFilter.vue
@@ -37,7 +37,7 @@ const selectedLocations = computed({
 
 <template>
   <div class="grid grid-cols-10 gap-4">
-    <h3 class="col-span-1 text-lg font-bold">지역별</h3>
+    <h3 class="col-span-1 text-lg font-bold dark:text-black3">지역별</h3>
     <div class="col-span-9 flex flex-wrap gap-2">
       <div v-for="location in locations" :key="location">
         <input
@@ -50,9 +50,10 @@ const selectedLocations = computed({
         />
         <label
           :for="location"
-          class="text-body1 px-4 py-1 border rounded-full cursor-pointer transition-colors"
+          class="text-body1 px-4 py-1 border rounded-full cursor-pointer transition-colors dark:text-black3 dark:border-black3"
           :class="{
-            'bg-primaryRed text-white border-primaryRed': selectedLocations.includes(location),
+            'bg-primaryRed text-white border-primaryRed dark:bg-primaryRed dark:text-black1 dark:border-primaryRed':
+              selectedLocations.includes(location),
           }"
         >
           {{ location }}

--- a/src/components/search/MemberCountFilter.vue
+++ b/src/components/search/MemberCountFilter.vue
@@ -27,7 +27,7 @@ const selectedCounts = computed({
 
 <template>
   <div class="grid grid-cols-10 gap-4">
-    <h3 class="col-span-1 text-lg font-bold">인원</h3>
+    <h3 class="col-span-1 text-lg font-bold dark:text-black3">인원</h3>
     <div class="col-span-9 flex flex-wrap gap-2">
       <div v-for="count in memberCounts" :key="count.value">
         <input
@@ -39,9 +39,10 @@ const selectedCounts = computed({
         />
         <label
           :for="'member-count-' + count.value"
-          class="text-body1 px-4 py-1 border rounded-full cursor-pointer transition-colors"
+          class="text-body1 px-4 py-1 border rounded-full cursor-pointer transition-colors dark:text-black3 dark:border-black3"
           :class="{
-            'bg-primaryRed text-white border-primaryRed': selectedCounts.includes(count.value),
+            'bg-primaryRed text-white border-primaryRed dark:bg-primaryRed dark:text-black1 dark:border-primaryRed':
+              selectedCounts.includes(count.value),
           }"
         >
           {{ count.label }}

--- a/src/views/bicycle/Bicycle.vue
+++ b/src/views/bicycle/Bicycle.vue
@@ -1,143 +1,44 @@
 <script setup>
-import BasicHeader from '@/components/BasicHeader.vue';
-import BasicFooter from '@/components/BasicFooter.vue';
-import bikeBrand from '../../../public/bike_category_data.json';
-import { onMounted, ref } from 'vue';
-import { Swiper, SwiperSlide } from 'swiper/vue';
-import 'swiper/css';
-import 'swiper/css/pagination';
-import 'swiper/css/navigation';
-import  './swiperCss.css'
-import { Pagination, Navigation } from 'swiper/modules';
+import BasicHeader from '@/components/BasicHeader.vue'
+import BasicFooter from '@/components/BasicFooter.vue'
+import BicycleBanner from './components/BicycleBanner.vue'
+import NewProductSection from './components/NewProductSection.vue'
+import BicycleIntroSection from './components/BicycleIntroSection.vue'
+import TopBrandSection from './components/TopBrandSection.vue'
 
-const groupList = ref([]);
-const modules = [Pagination, Navigation];
-const groupedItems = ref([]);
+import bikeBrand from '../../../public/bike_category_data.json'
+import { onMounted, ref } from 'vue'
+
+const groupList = ref([])
+const groupedItems = ref([])
 
 onMounted(() => {
-  const tempList = [];
-  for(const item in bikeBrand) {
-    if(item !== "KID") {
-      for(let i = 0; i < 4; i++) {
+  const tempList = []
+  for (const item in bikeBrand) {
+    if (item !== 'KID') {
+      for (let i = 0; i < 4; i++) {
         tempList.push(bikeBrand[item][i])
       }
     }
   }
-  groupList.value = tempList;
-  const chunkedList = [];
+  groupList.value = tempList
+  const chunkedList = []
   for (let i = 0; i < tempList.length; i += 4) {
-    chunkedList.push(tempList.slice(i, i + 4));
+    chunkedList.push(tempList.slice(i, i + 4))
   }
-  groupedItems.value = chunkedList;
+  groupedItems.value = chunkedList
 })
-
-
 </script>
 
 <template>
   <div class="w-full block h-full dark:bg-black9">
-    <BasicHeader/>
-    <div class="h-full dark:bg-black9">
-      <img class="w-full" src="../../../public/bicyclePageImage/ridePageHero.png">
-      <div class="relative -top-[350px] left-[92px]">
-        <div class="absolute">
-          <p class="text-black1 text-[32px] font-sans">Embrace the journey, unleash your spirit.</p>
-          <p class="text-black1 text-[60px] font-impact">Wherever you want, RideOn</p>
-          <router-link to="bicycleSearch">
-            <div class="w-[160px] h-[48px] border-2 border-black1 rounded-3xl text-black1">
-              <p class="m-auto text-center mt-2 h-[24px] text-black1 text-[20px] text-sub-title">See More</p>
-            </div>
-          </router-link>
-        </div>
-      </div>
-      <div class="mt-[130px] w-[1440px] mx-auto">
-        <div class="flex justify-between mx-[44px]">
-          <div>
-            <p class="text-primaryRed font-impact mb-1">New</p>
-            <p class="font-impact text-primaryRed">Product</p>
-          </div>
-          <div class="w-full border border-black4 h-0 mt-[22px] mx-[20px] "></div>
-          <router-link to="bicycleSearch">
-            <div class="flex bg-black9 dark:bg-black1 w-[164px] h-[46px] rounded-3xl justify-center items-center">
-              <p class="text-black1 font-impact dark:text-black9 mb-0">구매하러 가기</p>
-              <svg width="22" height="21" viewBox="0 0 22 21" xmlns="http://www.w3.org/2000/svg">
-                <path d="M15.5938 7.375L18.875 10.5M18.875 10.5L15.5938 13.625M18.875 10.5H3.125" class="stroke-black1 dark:stroke-black9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-              </svg>
-            </div>
-          </router-link>
-        </div>
-        <swiper
-          v-if="groupList.length > 0"
-          :slidesPerView="1"
-          :spaceBetween="30"
-          :loop="true"
-          :pagination="{clickable: true,}"
-          :navigation="true"
-          :modules="modules"
-          class="mySwiper px-11 dark:bg-black9 pb-1"
-        >
-          <swiper-slide v-for="(group, index) in groupedItems" :key="index">
-            <div class="grid grid-cols-4 gap-4 dark:bg-black9">
-              <div v-for="(item, i) in group" :key="i" class="p-4">
-                <img :src="item.image" alt="Bike Image" class="w-full h-auto border">
-                <p class="text-sm font-sans mb-1 mt-1 text-left dark:text-black3">{{ item.brand }}</p>
-                <p class="font-impact text-left mb-2 dark:text-black1">{{ item.name }}</p>
-                <p class="font-impact text-left dark:text-black1 ">{{ item.price }}원</p>
-              </div>
-            </div>
-          </swiper-slide>
-        </swiper>
-      </div>
-      <div class="border-2 flex w-[1352px] h-[660px] mt-[120px] mx-auto">
-        <div class="w-[630px]">
-          <div class="ml-8 mt-8">
-            <p class="mb-1 font-impact text-2xl dark:text-black1">역대급으로 빠르고,</p>
-            <p class="font-impact text-2xl dark:text-black1">역대급으로 가벼운</p>
-            <p class="font-sans dark:text-black1">가장 가볍고 빠른 슈퍼바이크의 놀라운 조합으로 완전히 새롭게 탄생한 마돈 8세대를 타고 질주해 보세요.</p>
-            <router-link to="bicycleSearch">
-              <div class=" border-2 rounded-full w-[160px] border-black9 dark:border-black1 mb-10">
-                <p class="text-center font-impact my-2 dark:text-black1">더 알아보기</p>
-              </div>
-            </router-link>
-          </div>
-          <img src="../../../public/bicyclePageImage/trekBike.png"/>
-        </div>
-        <div class="border-l-2">
-          <img class="h-1/2" src="../../../public/bicyclePageImage/trekBike2.png">
-          <div class="w-[297px] mx-auto mt-8">
-            <p class="font-sans text-[11px] leading-5 mb-[130px] dark:text-black1">가벼운 500 시리즈 OCLV 카본이 더욱 빠른 속도를 위해 새롭게 디자인 된 에어로 튜브 형태와 페어링되어 역대급으로 가벼운 마돈 SL 디스크 에어로 클라이밍 바이크로 탄생했습니다.</p>
-            <p class="font-sans dark:text-black1">(마돈 7세대 보다)</p>
-            <p class="font-impact text-3xl dark:text-black1">320g 더 가볍게</p>
-          </div>
-        </div>
-        <div>
-          <div class="w-[297px] mx-auto mt-8">
-            <p class="font-impact text-3xl mb-2 dark:text-black1">77s 더 빠르게</p>
-            <p class="font-sans mb-[160px] dark:text-black1">(에몬다 보다)</p>
-            <p class="font-sans text-[11px] leading-5 mb-7 dark:text-black1">빠른 스피드와 에어로함을 재정의하는 혁신적인 풀시스템 에어로 튜브 모양이 바이크 전체의 공기역학적 성능을 최적화합니다.</p>
-          </div>
-          <img class="h-1/2" src="../../../public/bicyclePageImage/SLImage.png">
-        </div>
-      </div>
-      <div class="w-[1352px] mt-[120px] mx-auto">
-        <p class="text-primaryRed font-impact text-2xl">TOP BRAND</p>
-        <div class="flex justify-between">
-          <img src="../../../public/bicyclePageImage/K2.png">
-          <img src="../../../public/bicyclePageImage/elfama.png">
-          <img src="../../../public/bicyclePageImage/sam.png">
-          <img src="../../../public/bicyclePageImage/twitter.png">
-        </div>
-      </div>
-    </div>
+    <BasicHeader />
+    <BicycleBanner />
+    <section class="w-[1440px] mx-auto my-[120px] px-[93px] flex flex-col gap-[120px]">
+      <NewProductSection :groupedItems="groupedItems" :groupList="groupList" />
+      <BicycleIntroSection />
+      <TopBrandSection />
+    </section>
     <BasicFooter />
   </div>
 </template>
-
-<style>
-.swiper-button-next, .swiper-button-prev {
-  @apply text-black10 dark:text-black1;
-}
-.swiper-pagination-bullet-active {
-  @apply bg-black10 dark:bg-black1;
-}
-</style>

--- a/src/views/bicycle/components/BicycleBanner.vue
+++ b/src/views/bicycle/components/BicycleBanner.vue
@@ -1,0 +1,21 @@
+<script setup></script>
+
+<template>
+  <section class="w-full h-[600px] bg-black2 relative">
+    <img
+      src="/bicyclePageImage/ridePageHero.png"
+      alt="banner text"
+      class="w-full h-full object-cover"
+    />
+    <div class="absolute w-[1440px] px-[93px] bottom-20 left-1/2 -translate-x-1/2">
+      <p class="text-black1 text-title font-light m-0">Embrace the journey, unleash your spirit.</p>
+      <p class="text-black1 text-[60px] font-impact mb-4">Wherever you want, RideOn</p>
+      <router-link
+        to="bicycleSearch"
+        class="text-black1 text-sub-title px-6 py-2 border border-black1 rounded-full"
+      >
+        See More
+      </router-link>
+    </div>
+  </section>
+</template>

--- a/src/views/bicycle/components/BicycleIntroSection.vue
+++ b/src/views/bicycle/components/BicycleIntroSection.vue
@@ -1,0 +1,44 @@
+<script setup></script>
+
+<template>
+  <article class="border-2 flex">
+    <div class="w-[630px]">
+      <div class="mx-8 mt-8">
+        <p class="mb-1 font-impact text-2xl dark:text-black1">역대급으로 빠르고,</p>
+        <p class="font-impact text-2xl dark:text-black1">역대급으로 가벼운</p>
+        <p class="text-body1 dark:text-black1">
+          가장 가볍고 빠른 슈퍼바이크의 놀라운 조합으로 완전히 새롭게 탄생한 마돈 8세대를 타고
+          질주해 보세요.
+        </p>
+        <router-link to="bicycleSearch">
+          <div class="border-2 rounded-full w-[160px] border-black9 dark:border-black1 mb-10">
+            <p class="text-center font-impact my-2 dark:text-black1">더 알아보기</p>
+          </div>
+        </router-link>
+      </div>
+      <img src="/bicyclePageImage/trekBike.png" />
+    </div>
+    <div class="border-l-2">
+      <img class="h-1/2" src="/bicyclePageImage/trekBike2.png" />
+      <div class="w-[297px] mx-auto mt-8">
+        <p class="text-body2 font-light leading-loose mb-[80px] dark:text-black1">
+          가벼운 500 시리즈 OCLV 카본이 더욱 빠른 속도를 위해 새롭게 디자인 된 에어로 튜브 형태와
+          페어링되어 역대급으로 가벼운 마돈 SL 디스크 에어로 클라이밍 바이크로 탄생했습니다.
+        </p>
+        <p class="dark:text-black1">(마돈 7세대 보다)</p>
+        <p class="font-impact text-3xl dark:text-black1">320g 더 가볍게</p>
+      </div>
+    </div>
+    <div>
+      <div class="w-[297px] mx-auto mt-8">
+        <p class="font-impact text-3xl mb-2 dark:text-black1">77s 더 빠르게</p>
+        <p class="mb-[115px] dark:text-black1">(에몬다 보다)</p>
+        <p class="text-body2 font-light leading-loose mb-7 dark:text-black1">
+          빠른 스피드와 에어로함을 재정의하는 혁신적인 풀시스템 에어로 튜브 모양이 바이크 전체의
+          공기역학적 성능을 최적화합니다.
+        </p>
+      </div>
+      <img class="h-1/2" src="/bicyclePageImage/SLImage.png" />
+    </div>
+  </article>
+</template>

--- a/src/views/bicycle/components/NewProductSection.vue
+++ b/src/views/bicycle/components/NewProductSection.vue
@@ -1,0 +1,175 @@
+<script setup>
+import { ref } from 'vue'
+import { Swiper, SwiperSlide } from 'swiper/vue'
+import 'swiper/css'
+import 'swiper/css/pagination'
+import 'swiper/css/navigation'
+import { Pagination, Navigation } from 'swiper/modules'
+
+defineProps({
+  groupedItems: {
+    type: Array,
+    required: true,
+  },
+  groupList: {
+    type: Array,
+    required: true,
+  },
+})
+
+const swiperRef = ref(null)
+const isBeginning = ref(true)
+const isEnd = ref(false)
+const modules = [Pagination, Navigation]
+
+const handleNext = () => {
+  if (swiperRef.value) {
+    swiperRef.value.slideNext()
+  }
+}
+
+const handlePrev = () => {
+  if (swiperRef.value) {
+    swiperRef.value.slidePrev()
+  }
+}
+
+const handleSlideChange = (swiper) => {
+  isBeginning.value = swiper.isBeginning
+  isEnd.value = swiper.isEnd
+}
+</script>
+
+<template>
+  <article class="w-full flex flex-col gap-8">
+    <div class="flex items-center gap-8">
+      <div class="text-primaryRed text-title">
+        New <br />
+        Product
+      </div>
+      <hr class="w-full border-black4" />
+      <router-link
+        to="bicycleSearch"
+        class="flex gap-1 justify-center items-center text-sub-title text-black1 bg-black9 dark:bg-black1 dark:text-black9 min-w-44 px-4 py-2 rounded-3xl"
+      >
+        구매하러 가기
+        <svg width="22" height="21" viewBox="0 0 22 21" xmlns="http://www.w3.org/2000/svg">
+          <path
+            d="M15.5938 7.375L18.875 10.5M18.875 10.5L15.5938 13.625M18.875 10.5H3.125"
+            class="stroke-black1 dark:stroke-black9"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        </svg>
+      </router-link>
+    </div>
+    <div class="relative">
+      <div
+        class="p-[14px] w-[53px] h-[53px] rounded-full border border-black7 dark:border-black1 absolute top-[150px] -left-[80px] z-50 flex items-center justify-center cursor-pointer"
+        :class="{ hidden: isBeginning }"
+        @click="handlePrev"
+      >
+        <svg
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M15 19L8 12L15 5"
+            stroke="black"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            class="dark:stroke-black1"
+          />
+        </svg>
+      </div>
+      <div
+        class="p-[14px] w-[53px] h-[53px] rounded-full border border-black7 dark:border-black1 absolute top-[150px] -right-[80px] z-50 flex items-center justify-center cursor-pointer"
+        :class="{ hidden: isEnd }"
+        @click="handleNext"
+      >
+        <svg
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M9 5L16 12L9 19"
+            stroke="black"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            class="dark:stroke-black1"
+          />
+        </svg>
+      </div>
+
+      <swiper
+        v-if="groupList.length > 0"
+        :slidesPerView="1"
+        :spaceBetween="30"
+        :loop="true"
+        :pagination="{ clickable: true }"
+        :modules="modules"
+        class="mySwiper dark:bg-black9 pb-1"
+        @swiper="swiperRef = $event"
+        @slideChange="handleSlideChange"
+        :navigation="false"
+      >
+        <swiper-slide v-for="(group, index) in groupedItems" :key="index">
+          <div class="grid grid-cols-4 gap-4 dark:bg-black9">
+            <div v-for="(item, i) in group" :key="i" class="flex flex-col">
+              <div class="flex flex-col gap-1">
+                <div class="w-full h-[280px] border mb-1">
+                  <img :src="item.image" alt="Bike Image" class="size-full object-cover" />
+                </div>
+                <p class="text-body1 text-left dark:text-black3 m-0">
+                  {{ item.brand }}
+                </p>
+                <p class="text-sub-title text-left dark:text-black1 truncate mb-4">
+                  {{ item.name }}
+                </p>
+              </div>
+              <p class="text-2xl text-left font-bold dark:text-black1">
+                {{ Intl.NumberFormat('ko-KR').format(Number(item.price)) }}원
+              </p>
+            </div>
+          </div>
+        </swiper-slide>
+      </swiper>
+    </div>
+  </article>
+</template>
+
+<style>
+.swiper-button-next,
+.swiper-button-prev {
+  display: none !important;
+}
+
+.swiper-pagination-bullet {
+  @apply bg-black7 dark:bg-black5;
+}
+
+.swiper-pagination-bullet-active {
+  @apply bg-black10 dark:bg-black1;
+}
+
+.swiper-pagination {
+  position: relative !important;
+  margin-top: 20px !important;
+  bottom: 0 !important;
+}
+
+.swiper-pagination-bullet {
+  margin: 0 5px !important;
+  width: 12px !important;
+  height: 12px !important;
+}
+</style>

--- a/src/views/bicycle/components/TopBrandSection.vue
+++ b/src/views/bicycle/components/TopBrandSection.vue
@@ -1,0 +1,13 @@
+<script setup></script>
+
+<template>
+  <article class="w-full flex flex-col gap-8">
+    <p class="text-primaryRed text-title font-bold">TOP BRAND</p>
+    <div class="w-full grid grid-cols-4 gap-6">
+      <img src="/bicyclePageImage/K2.png" />
+      <img src="/bicyclePageImage/elfama.png" />
+      <img src="/bicyclePageImage/sam.png" />
+      <img src="/bicyclePageImage/twitter.png" />
+    </div>
+  </article>
+</template>

--- a/src/views/freeBoard/FreeBoard.vue
+++ b/src/views/freeBoard/FreeBoard.vue
@@ -66,7 +66,7 @@ onMounted(async () => {
       </section>
 
       <!-- 게시글 목록 영역 -->
-      <section class="grid grid-cols-12 gap-4">
+      <section class="grid grid-cols-12 grid-rows-2 gap-4 min-h-[512px]">
         <FreeBoardListItem v-for="post in filteredPosts" :key="post._id" :post="post" />
       </section>
     </main>

--- a/src/views/qnaBoard/QnaBoard.vue
+++ b/src/views/qnaBoard/QnaBoard.vue
@@ -100,7 +100,7 @@ const handleWriteClick = () => {
         </section>
 
         <!-- 질문 게시판 목록 -->
-        <section class="flex flex-col items-start">
+        <section class="flex flex-col min-h-[512px]">
           <QnaListItem v-for="qna in filteredQnas" :key="qna.id" :qna="qna" />
         </section>
       </article>

--- a/src/views/qnaBoard/components/QnaListItem.vue
+++ b/src/views/qnaBoard/components/QnaListItem.vue
@@ -15,7 +15,7 @@ defineProps({
       name: 'QnaBoardDetail',
       params: { id: qna._id },
     }"
-    class="w-full flex flex-col gap-6 items-start py-8 border-t border-black3 dark:border-black6"
+    class="w-full flex flex-col gap-6 items-start py-8 border-t border-black3 dark:border-black6 grow-0"
   >
     <!-- 질문 정보 상단 -->
     <div class="flex flex-col gap-4">

--- a/src/views/riderCrewBoard/crewBoardWrite/RiderCrewBoardWrite.vue
+++ b/src/views/riderCrewBoard/crewBoardWrite/RiderCrewBoardWrite.vue
@@ -105,9 +105,10 @@ const CONTENT_PLACEHOLDER =
                   />
                   <label
                     :for="location"
-                    class="text-body1 px-4 py-1 border rounded-full cursor-pointer transition-colors"
+                    class="text-body1 px-4 py-1 border rounded-full cursor-pointer transition-colors dark:text-black3 dark:border-black3"
                     :class="{
-                      'bg-primaryRed text-white border-primaryRed': selectedLocation === location,
+                      'bg-primaryRed text-white border-primaryRed dark:bg-primaryRed dark:text-black1 dark:border-primaryRed':
+                        selectedLocation === location,
                     }"
                   >
                     {{ location }}
@@ -131,9 +132,9 @@ const CONTENT_PLACEHOLDER =
                   />
                   <label
                     :for="'member-count-' + count.value"
-                    class="text-body1 px-4 py-1 border rounded-full cursor-pointer transition-colors"
+                    class="text-body1 px-4 py-1 border rounded-full cursor-pointer transition-colors dark:text-black3 dark:border-black3"
                     :class="{
-                      'bg-primaryRed text-white border-primaryRed':
+                      'bg-primaryRed text-white border-primaryRed dark:bg-primaryRed dark:text-black1 dark:border-primaryRed':
                         selectedMemberCount === count.value,
                     }"
                   >


### PR DESCRIPTION
### feat: 라이더 크루 네비게이션 추가 및 스타일 수정  

## 🔘Part  
- [x] FE  

<br/>  

## 🔎 작업 내용  
- 네비게이션에 라이더 크루 추가  
- 검색 시 `item` 최소 높이 지정하여 UI 안정화  
- 라이더 크루 UI에서 누락된 다크모드 스타일 추가  
- `Bicycle` 메인 페이지 퍼블리싱 스타일 수정  

<br/>  

## 이미지 첨부  

<img src="https://github.com/user-attachments/assets/83505126-2ec2-44f6-aa91-5252fcdfffec" width="50%" height="50%"/>

<br/>  

## 🔧 앞으로의 과제  
- 라이더 크루 페이지 UI 세부 조정  
- 다크모드 스타일 전반적인 점검 및 개선  
