### PR TITLE
자전거 상세페이지 가격 NaN 오류 수정 

### DIFF
--- a/src/views/bicycle/bicycleDetail/BicycleDetail.vue
+++ b/src/views/bicycle/bicycleDetail/BicycleDetail.vue
@@ -52,6 +52,14 @@ const likeRemoveHandler = async () => {
     await fetchLikeRemoveApi({ id: user._id, title: id })
   }
 }
+
+const formatPrice = (price) => {
+  if (typeof price === 'string') {
+    return price
+  } else {
+    return Intl.NumberFormat('ko-KR').format(price)
+  }
+}
 </script>
 
 <template>
@@ -76,7 +84,7 @@ const likeRemoveHandler = async () => {
             </div>
             <div>
               <p class="font-impact text-right text-3xl dark:text-black1">
-                {{ Intl.NumberFormat('ko-KR').format(Number(price || 0)) }}원
+                {{ formatPrice(item.price) }}원
               </p>
               <div class="bg-primaryRed p-2 rounded-lg mb-2">
                 <p class="text-black1 mb-0 font-bold text-center">구매하러 가기</p>

--- a/src/views/bicycle/bicycleDetail/BicycleDetail.vue
+++ b/src/views/bicycle/bicycleDetail/BicycleDetail.vue
@@ -178,9 +178,7 @@ const formatPrice = (price) => {
               </div>
               <p class="text-body2 mb-1 dark:text-black1">{{ item.brand }}</p>
               <p class="text-sub-title mb-2 truncate dark:text-black1">{{ item.name }}</p>
-              <p class="font-bold mb-4 text-2xl dark:text-black1">
-                {{ Intl.NumberFormat('ko-KR').format(Number(item.price || 0)) }}원
-              </p>
+              <p class="font-bold mb-4 text-2xl dark:text-black1">{{ formatPrice(price) }}원</p>
               <div class="flex bg-black1 justify-center align-center py-2">
                 <svg
                   width="17"

--- a/src/views/bicycle/bicycleDetail/BicycleDetail.vue
+++ b/src/views/bicycle/bicycleDetail/BicycleDetail.vue
@@ -84,7 +84,7 @@ const formatPrice = (price) => {
             </div>
             <div>
               <p class="font-impact text-right text-3xl dark:text-black1">
-                {{ formatPrice(item.price) }}원
+                {{ formatPrice(price) }}원
               </p>
               <div class="bg-primaryRed p-2 rounded-lg mb-2">
                 <p class="text-black1 mb-0 font-bold text-center">구매하러 가기</p>

--- a/src/views/bicycle/bicycleSearch/BicycleSearch.vue
+++ b/src/views/bicycle/bicycleSearch/BicycleSearch.vue
@@ -339,7 +339,7 @@ const formatPrice = (price) => {
                     brand: item.brand,
                     category: item.category,
                     name: item.name,
-                    price: item.price,
+                    price: formatPrice(item.price),
                     image: item.image,
                   },
                 }"

--- a/src/views/bicycle/components/NewProductSection.vue
+++ b/src/views/bicycle/components/NewProductSection.vue
@@ -38,6 +38,14 @@ const handleSlideChange = (swiper) => {
   isBeginning.value = swiper.isBeginning
   isEnd.value = swiper.isEnd
 }
+
+const formatPrice = (price) => {
+  if (typeof price === 'string') {
+    return price
+  } else {
+    return Intl.NumberFormat('ko-KR').format(price)
+  }
+}
 </script>
 
 <template>
@@ -137,7 +145,7 @@ const handleSlideChange = (swiper) => {
                         brand: item.brand,
                         category: item.category,
                         name: item.name,
-                        price: item.price,
+                        price: formatPrice(item.price),
                         image: item.image,
                       },
                     }"
@@ -153,7 +161,7 @@ const handleSlideChange = (swiper) => {
                 </p>
               </div>
               <p class="text-2xl text-left font-bold dark:text-black1">
-                {{ Intl.NumberFormat('ko-KR').format(Number(item.price)) }}원
+                {{ formatPrice(item.price) }}원
               </p>
             </div>
           </div>


### PR DESCRIPTION
### fix: 자전거 상세페이지 가격 NaN 오류 수정  

## 🔘Part  
- [x] FE  

<br/>  

## 🔎 작업 내용  
- **자전거 상세페이지에서 가격이 `NaN`으로 표시되던 오류 수정**  
- **item.price -> price 오타 수정**  
- **자전거 가격에 포매팅 적용**

<br/>  

## 🔧 앞으로의 과제  
- **가격 데이터 유효성 검증 추가**  
- **API 응답 예외 처리 보강**  